### PR TITLE
Add /usr/local e2fsprogs fallback paths

### DIFF
--- a/guest/image/build.sh
+++ b/guest/image/build.sh
@@ -63,7 +63,11 @@ elif [[ "$(uname -s)" == "Darwin" ]]; then
         /opt/homebrew/opt/e2fsprogs/sbin/mke2fs \
         /opt/homebrew/opt/e2fsprogs/bin/mke2fs \
         /opt/homebrew/opt/e2fsprogs/sbin/mkfs.ext4 \
-        /opt/homebrew/opt/e2fsprogs/bin/mkfs.ext4; do
+        /opt/homebrew/opt/e2fsprogs/bin/mkfs.ext4 \
+        /usr/local/opt/e2fsprogs/sbin/mke2fs \
+        /usr/local/opt/e2fsprogs/bin/mke2fs \
+        /usr/local/opt/e2fsprogs/sbin/mkfs.ext4 \
+        /usr/local/opt/e2fsprogs/bin/mkfs.ext4; do
         if [[ -x "${candidate}" ]]; then
             MKFS_EXT4="${candidate}"
             break

--- a/host/src/build-alpine.ts
+++ b/host/src/build-alpine.ts
@@ -710,6 +710,10 @@ function findMke2fs(): string {
       "/opt/homebrew/opt/e2fsprogs/bin/mke2fs",
       "/opt/homebrew/opt/e2fsprogs/sbin/mkfs.ext4",
       "/opt/homebrew/opt/e2fsprogs/bin/mkfs.ext4",
+      "/usr/local/opt/e2fsprogs/sbin/mke2fs",
+      "/usr/local/opt/e2fsprogs/bin/mke2fs",
+      "/usr/local/opt/e2fsprogs/sbin/mkfs.ext4",
+      "/usr/local/opt/e2fsprogs/bin/mkfs.ext4",
     ];
     for (const candidate of candidates) {
       if (fs.existsSync(candidate)) {


### PR DESCRIPTION
Slopped it.

This makes building on Intel macOS possible without having to re-configure the PATH.