### PR TITLE
fix: prevent unbounded output buffering in ExecProcess.attach()

### DIFF
--- a/host/src/exec.ts
+++ b/host/src/exec.ts
@@ -356,6 +356,7 @@ export class ExecProcess implements PromiseLike<ExecResult>, AsyncIterable<strin
       throw new Error("already attached");
     }
     this.attached = true;
+    this.session.iterating = true;
 
     const stderrOut = stderr ?? stdout;
 


### PR DESCRIPTION
fixes https://github.com/earendil-works/gondolin/issues/13

it is a one line change, setting `this.session.iterating = true` in `attach()` which prevents unbounded buffering. However, it also means await proc will now return `result.stdout === "" / result.stderr === ""` even though output was produced. 
This changes the behavior for callers who might expect buffered output in the final ExecResult. I guess the alternative would be to add a cap on the buffer size if it is needed, but it seems nobody uses `result.stdout` after `attach()` at the moment. 

The new test was slopped by opus/codex. 