### PR TITLE
fix(vfs): strip O_CREAT from open RPC flags for existing files

### DIFF
--- a/host/src/vfs/rpc.ts
+++ b/host/src/vfs/rpc.ts
@@ -508,7 +508,8 @@ export class RpcFsBackend extends VirtualProviderClass implements VirtualProvide
     if (!entry) {
       throw createErrnoError(ERRNO.ENOENT, "open", entryPath);
     }
-    const response = await this.client.request("open", { ino: entry.ino, flags: flagInfo.numeric });
+    const openFlags = flagInfo.numeric & ~fs.constants.O_CREAT;
+    const response = await this.client.request("open", { ino: entry.ino, flags: openFlags });
     assertOk(response, "open", entryPath);
     const fh = response.p.res?.fh as number;
     if (flagInfo.truncate) {
@@ -832,4 +833,3 @@ function normalizePath(entryPath: string) {
   }
   return normalized === "" ? "/" : normalized;
 }
-

--- a/host/test/rpc-backend-open-flags.test.ts
+++ b/host/test/rpc-backend-open-flags.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+import { RpcFsBackend, FsRpcService, MemoryProvider } from "../src/vfs";
+
+async function send(service: FsRpcService, op: string, req: Record<string, unknown>, id: number) {
+  return service.handleRequest({
+    v: 1,
+    t: "fs_request",
+    id,
+    p: { op, req },
+  });
+}
+
+test("rpc backend does not leak O_CREAT into open RPC for existing files", async () => {
+  const service = new FsRpcService(new MemoryProvider());
+  let id = 1;
+  const openFlags: number[] = [];
+
+  const create = await send(
+    service,
+    "create",
+    {
+      parent_ino: 1,
+      name: "existing.txt",
+      mode: 0o644,
+      flags: 0,
+    },
+    id++
+  );
+  assert.equal(create.p.err, 0);
+
+  const client = {
+    request(op: string, req: Record<string, unknown>) {
+      if (op === "open") {
+        openFlags.push(req.flags as number);
+      }
+      return send(service, op, req, id++);
+    },
+    close() {},
+  };
+
+  const backend = new RpcFsBackend(client as any);
+
+  const writeHandle = await backend.open("/existing.txt", "w");
+  await writeHandle.close();
+
+  const appendHandle = await backend.open("/existing.txt", "a");
+  await appendHandle.close();
+
+  assert.equal(openFlags.length, 2);
+  assert.equal(openFlags[0] & fs.constants.O_CREAT, 0);
+  assert.equal(openFlags[1] & fs.constants.O_CREAT, 0);
+
+  await service.close();
+});


### PR DESCRIPTION
## Summary
Fixes `RpcFsBackend.open()` leaking `O_CREAT` into the `open` RPC path for existing files, which caused `EINVAL` for write/append opens.

## Changes
- Updated `host/src/vfs/rpc.ts` to clear `O_CREAT` before sending `open` RPC flags.
- Added regression test `host/test/rpc-backend-open-flags.test.ts` covering `"w"` and `"a"` on existing files.

## Validation
Implemented using Red Green: Test first then fix.
- `pnpm exec tsx --test test/rpc-backend-open-flags.test.ts`
- `pnpm exec tsx --test test/fs-rpc.test.ts`

Fixes #27 