### PR TITLE
fix(build): resolve initramfs modules across compression formats

### DIFF
--- a/host/test/build-alpine-modules.test.ts
+++ b/host/test/build-alpine-modules.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Owns regression coverage for initramfs kernel-module selection in the Alpine builder
+ * Does not own end-to-end image build or VM boot integration behavior
+ * Invariant: required boot modules resolve regardless of compression suffix
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { __test } from "../src/build-alpine";
+
+function writeFile(filePath: string, content = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+test("build-alpine: copyInitramfsModules resolves compressed modules from modules.dep", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-build-alpine-modules-"));
+  const srcDir = path.join(tmpDir, "src");
+  const dstDir = path.join(tmpDir, "dst");
+
+  try {
+    const deps = [
+      "kernel/drivers/block/virtio_blk.ko.zst:",
+      "kernel/fs/ext4/ext4.ko.zst: kernel/fs/jbd2/jbd2.ko.zst kernel/crypto/crc32c_generic.ko.zst kernel/lib/libcrc32c.ko.zst",
+      "kernel/fs/jbd2/jbd2.ko.zst:",
+      "kernel/crypto/crc32c_generic.ko.zst:",
+      "kernel/lib/libcrc32c.ko.zst:",
+    ].join("\n");
+
+    writeFile(path.join(srcDir, "modules.dep"), `${deps}\n`);
+    writeFile(path.join(srcDir, "modules.alias"), "# test metadata\n");
+
+    writeFile(path.join(srcDir, "kernel/drivers/block/virtio_blk.ko.zst"));
+    writeFile(path.join(srcDir, "kernel/fs/ext4/ext4.ko.zst"));
+    writeFile(path.join(srcDir, "kernel/fs/jbd2/jbd2.ko.zst"));
+    writeFile(path.join(srcDir, "kernel/crypto/crc32c_generic.ko.zst"));
+    writeFile(path.join(srcDir, "kernel/lib/libcrc32c.ko.zst"));
+
+    __test.copyInitramfsModules(srcDir, dstDir);
+
+    const expectedModules = [
+      "kernel/drivers/block/virtio_blk.ko.zst",
+      "kernel/fs/ext4/ext4.ko.zst",
+      "kernel/fs/jbd2/jbd2.ko.zst",
+      "kernel/crypto/crc32c_generic.ko.zst",
+      "kernel/lib/libcrc32c.ko.zst",
+    ];
+
+    for (const entry of expectedModules) {
+      assert.equal(fs.existsSync(path.join(dstDir, entry)), true, `missing copied module: ${entry}`);
+    }
+
+    assert.equal(fs.existsSync(path.join(dstDir, "modules.dep")), true);
+    assert.equal(fs.existsSync(path.join(dstDir, "modules.alias")), true);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
`copyInitramfsModules` previously hardcoded required module names as `.ko.gz` (`virtio_blk`, `ext4`). This can miss required modules when Alpine/kernel packaging uses other suffixes (`.ko`, `.ko.xz`, `.ko.zst`), leading to incomplete initramfs module sets.

## What changed
- Switched required-module seeding to compression-agnostic resolution:
  - `kernel/drivers/block/virtio_blk.ko`
  - `kernel/fs/ext4/ext4.ko`
  - `kernel/crypto/crc32c_generic.ko`
  - `kernel/lib/libcrc32c.ko`
- Resolution now:
  1. prefers exact entries present in `modules.dep`
  2. falls back to checking common suffixes (`.ko`, `.ko.gz`, `.ko.xz`, `.ko.zst`) on disk
- Kept transitive dependency traversal via `modules.dep` unchanged.

## Regression coverage
Added `host/test/build-alpine-modules.test.ts`:
- builds a synthetic modules tree with `.ko.zst` entries
- verifies required + transitive modules are copied into initramfs output
- verifies `modules.*` metadata files are copied

## Why this is safe
- Scope is limited to initramfs module selection/copying in the Alpine builder path.
- No runtime VM/network/VFS behavior changes.
- Behavior remains backward compatible with `.ko.gz` while covering additional valid kernel packaging formats.

## Validation
- `make check`
- `cd host && pnpm exec tsx --test test/build-alpine-modules.test.ts`
