### PR TITLE
fix(vfs): prevent symlink escape in RealFSProvider

### DIFF
--- a/docs/vfs.md
+++ b/docs/vfs.md
@@ -89,6 +89,7 @@ Common pattern:
 `RealFSProvider(hostPath)` exposes a directory from the host filesystem.
 
 - Reads and writes affect the host directory
+- Symlinks inside the exposed directory that resolve outside it are blocked for operations that follow symlinks (open, stat, readdir, etc.).  Operations that act on the symlink entry itself (lstat, readlink, unlink) are allowed.
 - Use this for persistence (outputs, caches) or for sharing a source tree
 
 Example:


### PR DESCRIPTION
RealFSProvider._resolvePath() only checks path containment lexically (string prefix match after path.resolve). It does not resolve symlinks before the check, so any symlink inside the mounted directory that points outside the root will be followed by fs.openSync, fs.statSync, etc.

This means a guest VM can read and write arbitrary host files through symlinks — either pre-existing ones in the mounted directory or ones created by the guest itself (after FUSE cache TTL expires).

Impact: full host filesystem read/write from inside the sandbox, bypassing the VFS root boundary.

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
