### PR TITLE
feat(vm): add dedicated app channel transport for long-running guest daemon

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,7 @@ Guest daemons/components:
 - `sandboxfs`: a FUSE daemon that forwards filesystem operations to the host via RPC
 - `sandboxssh`: a dedicated host-to-guest TCP forwarder for SSH access (loopback-only inside the guest)
 - `sandboxingress`: a dedicated host-to-guest TCP forwarder for inbound HTTP traffic (ingress gateway)
+- guest application daemons can use `/dev/virtio-ports/virtio-app` for dedicated host <-> guest control traffic
 - `/init`: mounts tmpfs, brings up networking, starts services
 
 ### QEMU
@@ -84,6 +85,7 @@ See [QEMU](./qemu.md) for details.
 |  |  [virtio-serial]  fs RPC      <---------------->  VFS RPC service       | |
 |  |  [virtio-serial]  ssh fwd     <---------------->  loopback-only proxy   | |
 |  |  [virtio-serial]  ingress fwd <---------------->  ingress gateway       | |
+|  |  [virtio-serial]  app channel <---------------->  host app bridge       | |
 |  +-------------------------------------------------------------------------+ |
 |                                                                              |
 +------------------------------------------------------------------------------+
@@ -100,6 +102,7 @@ It's useful to think of Gondolin as two planes:
 
   - command execution (`vm.exec`)
   - filesystem RPC for the programmable mounts
+  - app-daemon host <-> guest traffic (`vm.openAppChannel()`)
   - a small set of host <-> guest utility channels
 
 - **Data plane:** guest-visible "normal" Linux interfaces

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -15,7 +15,8 @@ Set `GONDOLIN_DEBUG` to a comma-separated list of flags:
 - `net`: networking stack / HTTP bridge
 - `exec`: exec + stdin/pty control messages
 - `vfs`: VFS (FUSE/RPC) operations
-- `protocol`: virtio/control-protocol traffic and QEMU log forwarding
+- `protocol`: virtio/control-protocol traffic (including app channel) and QEMU
+  log forwarding
 - `all`: turns on everything
 
 Examples:

--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -27,7 +27,8 @@ From inside the VM, the guest sees familiar devices:
 
 - A block device for the root filesystem
 - A network interface (typically as eth0)
-- Four virtio-serial ports used for exec control, VFS RPC, SSH forwarding, and ingress
+- Five virtio-serial ports used for exec control, VFS RPC, SSH forwarding,
+  ingress, and dedicated app-channel traffic
 
 The guest experience is intentionally "normal Linux" so that standard tooling
 works without custom kernels or unusual userspace stacks.
@@ -38,7 +39,8 @@ Gondolin runs QEMU as a child process and connects to it over local transports
 (Unix domain sockets).  The host side is responsible for:
 
 - Launching and shutting down the VM process
-- Wiring up virtio channels used for exec control and filesystem RPC
+- Wiring up virtio channels used for exec control, filesystem RPC, and
+  dedicated utility backchannels
 - Providing a network backend that receives raw frames from QEMU
 
 The key design is that Gondolin does not treat QEMU networking as a black box.
@@ -67,7 +69,8 @@ Instead, Gondolin uses:
 
 - virtio-net for a normal guest network interface
 - a host network backend that receives and emits frames
-- virtio-serial ports for structured control protocols (exec, VFS RPC, SSH forwarding, and ingress)
+- virtio-serial ports for structured control protocols (exec, VFS RPC, SSH
+  forwarding, ingress, and app-channel traffic)
 
 This combination is stable, well-understood, and keeps the guest environment conventional.
 
@@ -97,8 +100,8 @@ Reasons:
 
 - Structured framing: messages can be length-delimited and authenticated by
   protocol invariants.
-- Separation of concerns: exec control and filesystem RPC are not mixed with
-  network traffic.
+- Separation of concerns: exec control, filesystem RPC, and utility
+  backchannels are not mixed with network traffic.
 - Cross-platform stability: virtio-serial is widely supported and behaves
   consistently across macOS and Linux when run under QEMU.
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -4,7 +4,7 @@ This section documents the programmatic API in `@earendil-works/gondolin`.
 
 To keep this easier to navigate, the SDK docs are split into focused guides:
 
-- [VM Lifecycle & Command Execution](./sdk-vm.md)
+- [VM Lifecycle, Command Execution, and App Channels](./sdk-vm.md)
 - [Networking, Ingress, and SSH](./sdk-network.md)
 - [Filesystem, Guest Assets, and Snapshots](./sdk-storage.md)
 
@@ -40,5 +40,4 @@ await vm.close();
 - [SSH](./ssh.md)
 - [VFS Providers](./vfs.md)
 - [Snapshots](./snapshots.md)
-
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -285,6 +285,20 @@ host <-> guest control feature.
 **Guarantee:** this API cannot be used to reach arbitrary guest network
 destinations; it only reaches services bound to guest loopback.
 
+`VM.openAppChannel()` opens a dedicated raw byte stream over a separate
+virtio-serial port (`virtio-app`) for long-running guest daemons.
+Guest daemons typically bind this via `/dev/virtio-ports/virtio-app`.
+
+This channel is also intentionally outside guest egress network policy because
+it is host <-> guest control traffic.
+
+**Guarantee:** this API does not give the guest arbitrary host network access.
+It is a direct control path between host code and a specific guest daemon.
+
+**Important:** the app channel provides transport only. Authentication,
+authorization, message framing, replay protection, and rate limiting are
+application-level responsibilities of the protocol you run on top.
+
 ## Why the Design Is Secure
 
 Secure here means secure within our design goals.

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -12,6 +12,8 @@ export {
   type VMState,
   type EnableSshOptions,
   type SshAccess,
+  type AppChannel,
+  type AppChannelEvent,
   type VmFs,
   type VmRootfsOptions,
   type VmFsAccessOptions,

--- a/host/src/sandbox/controller.ts
+++ b/host/src/sandbox/controller.ts
@@ -68,6 +68,8 @@ export type SandboxConfig = {
 
   /** virtio-serial ingress socket path */
   virtioIngressSocketPath: string;
+  /** virtio-serial application socket path */
+  virtioAppSocketPath: string;
   /** kernel cmdline append string */
   append: string;
   /** qemu machine type */
@@ -384,6 +386,10 @@ function buildQemuArgs(config: SandboxConfig) {
     "-chardev",
     `socket,id=virtioingress0,path=${config.virtioIngressSocketPath},server=off`,
   );
+  args.push(
+    "-chardev",
+    `socket,id=virtioapp0,path=${config.virtioAppSocketPath},server=off`
+  );
 
   args.push("-device", `${serialDev},id=virtio-serial0`);
   args.push(
@@ -401,6 +407,10 @@ function buildQemuArgs(config: SandboxConfig) {
   args.push(
     "-device",
     "virtserialport,chardev=virtioingress0,name=virtio-ingress,bus=virtio-serial0.0",
+  );
+  args.push(
+    "-device",
+    "virtserialport,chardev=virtioapp0,name=virtio-app,bus=virtio-serial0.0"
   );
 
   if (config.netSocketPath) {

--- a/host/src/sandbox/server-ops.ts
+++ b/host/src/sandbox/server-ops.ts
@@ -26,6 +26,7 @@ import {
   type GuestFileWriteOptions,
 } from "./server-options.ts";
 import {
+  AppStream,
   MAX_REQUEST_ID,
   TcpForwardStream,
   estimateBase64Bytes,
@@ -510,6 +511,32 @@ export class SandboxServerOps {
     }
   }
 
+  /**
+   * Open the dedicated application channel stream used by long-running guest daemons.
+   */
+  openAppStream(): AppStream {
+    const existing = this.appStream;
+    if (existing && !existing.destroyed) {
+      return existing;
+    }
+
+    const stream = new AppStream(
+      (m) => this.appBridge.send(m),
+      () => {
+        if (this.appStream === stream) {
+          this.appStream = null;
+        }
+      },
+    );
+    this.appStream = stream;
+
+    if (this.appBridge.isConnected()) {
+      stream.markConnected();
+    }
+
+    return stream;
+  }
+
   broadcastStatus(state: SandboxState) {
     for (const client of this.clients) {
       sendJson(client, { type: "status", state });
@@ -575,6 +602,7 @@ export class SandboxServerOps {
     this.fsBridge.connect();
     this.sshBridge.connect();
     this.ingressBridge.connect();
+    this.appBridge.connect();
   }
 
   async closeInternal() {
@@ -588,6 +616,7 @@ export class SandboxServerOps {
       this.fsBridge.disconnect(),
       this.sshBridge.disconnect(),
       this.ingressBridge.disconnect(),
+      this.appBridge.disconnect(),
     ]);
 
     // Tear down host-side network + streams promptly. QEMU may still be running
@@ -605,6 +634,11 @@ export class SandboxServerOps {
     }
     this.ingressTcpStreams.clear();
     this.ingressTcpOpenWaiters.clear();
+
+    if (this.appStream) {
+      this.appStream.destroy();
+      this.appStream = null;
+    }
 
     await this.controller.close();
     await this.fsService?.close();

--- a/host/src/sandbox/server-options.ts
+++ b/host/src/sandbox/server-options.ts
@@ -69,6 +69,8 @@ export type SandboxServerOptions = {
 
   /** virtio-serial ingress socket path */
   virtioIngressSocketPath?: string;
+  /** virtio-serial application socket path */
+  virtioAppSocketPath?: string;
   /** qemu net socket path */
   netSocketPath?: string;
   /** guest mac address */
@@ -189,6 +191,8 @@ export type ResolvedSandboxServerOptions = {
 
   /** virtio-serial ingress socket path */
   virtioIngressSocketPath: string;
+  /** virtio-serial application socket path */
+  virtioAppSocketPath: string;
   /** qemu net socket path */
   netSocketPath: string;
   /** guest mac address */
@@ -376,6 +380,10 @@ export function resolveSandboxServerOptions(
     tmpDir,
     `gondolin-virtio-ingress-${randomUUID().slice(0, 8)}.sock`,
   );
+  const defaultVirtioApp = path.resolve(
+    tmpDir,
+    `gondolin-virtio-app-${randomUUID().slice(0, 8)}.sock`,
+  );
   const defaultNetSock = path.resolve(
     tmpDir,
     `gondolin-net-${randomUUID().slice(0, 8)}.sock`,
@@ -456,6 +464,7 @@ export function resolveSandboxServerOptions(
     virtioSshSocketPath: options.virtioSshSocketPath ?? defaultVirtioSsh,
     virtioIngressSocketPath:
       options.virtioIngressSocketPath ?? defaultVirtioIngress,
+    virtioAppSocketPath: options.virtioAppSocketPath ?? defaultVirtioApp,
     netSocketPath: options.netSocketPath ?? defaultNetSock,
     netMac: options.netMac ?? defaultNetMac,
     netEnabled: options.netEnabled ?? true,

--- a/host/src/sandbox/server-transport.ts
+++ b/host/src/sandbox/server-transport.ts
@@ -30,6 +30,10 @@ export class VirtioBridge {
     this.maxPendingBytes = maxPendingBytes;
   }
 
+  isConnected(): boolean {
+    return this.socket !== null;
+  }
+
   connect() {
     if (this.closed) return;
     if (this.server) return;
@@ -117,6 +121,8 @@ export class VirtioBridge {
 
   onMessage?: (message: IncomingMessage) => void;
   onError?: (error: unknown) => void;
+  onConnected?: () => void;
+  onDisconnected?: () => void;
 
   /** Called when the bridge may be able to accept more queued messages */
   onWritable?: () => void;
@@ -167,6 +173,7 @@ export class VirtioBridge {
     }
     this.socket = socket;
     this.waitingDrain = false;
+    this.onConnected?.();
 
     socket.on("data", (chunk) => {
       try {
@@ -203,11 +210,15 @@ export class VirtioBridge {
   }
 
   private handleDisconnect() {
+    const hadSocket = this.socket !== null;
     if (this.socket) {
       this.socket.destroy();
       this.socket = null;
     }
     this.waitingDrain = false;
+    if (hadSocket) {
+      this.onDisconnected?.();
+    }
   }
 
   private scheduleReconnect() {
@@ -309,6 +320,79 @@ export class TcpForwardStream extends Duplex {
   openFailed(message: string): void {
     this.closedByRemote = true;
     this.destroy(new Error(message));
+  }
+}
+
+export class AppStream extends Duplex {
+  private connected = false;
+  private readonly sendFrame: (message: object) => boolean;
+  private readonly onDispose: () => void;
+
+  constructor(
+    sendFrame: (message: object) => boolean,
+    onDispose: () => void,
+  ) {
+    super();
+    this.sendFrame = sendFrame;
+    this.onDispose = onDispose;
+    this.on("close", () => {
+      this.onDispose();
+    });
+  }
+
+  _read(_size: number): void {
+    // no-op; data is pushed from virtio handler
+  }
+
+  _write(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    const ok = this.sendFrame({
+      v: 1,
+      t: "app_data",
+      id: 1,
+      p: { data: chunk },
+    });
+
+    if (!ok) {
+      callback(new Error("virtio app queue exceeded"));
+      return;
+    }
+
+    callback();
+  }
+
+  _final(callback: (error?: Error | null) => void): void {
+    callback();
+  }
+
+  _destroy(
+    _error: Error | null,
+    callback: (error?: Error | null) => void,
+  ): void {
+    callback();
+  }
+
+  pushRemote(data: Buffer): void {
+    this.push(data);
+  }
+
+  markConnected(): void {
+    if (this.connected) return;
+    this.connected = true;
+    this.emit("connected");
+  }
+
+  markDisconnected(): void {
+    if (!this.connected) return;
+    this.connected = false;
+    this.emit("disconnected");
+  }
+
+  isConnected(): boolean {
+    return this.connected;
   }
 }
 

--- a/host/src/sandbox/server.ts
+++ b/host/src/sandbox/server.ts
@@ -48,6 +48,7 @@ import {
   resolveSandboxServerOptionsAsync,
 } from "./server-options.ts";
 import {
+  AppStream,
   MAX_REQUEST_ID,
   TcpForwardStream,
   VirtioBridge,
@@ -163,6 +164,7 @@ export class SandboxServer extends EventEmitter {
   private readonly fsBridge: VirtioBridge;
   private readonly sshBridge: VirtioBridge;
   private readonly ingressBridge: VirtioBridge;
+  private readonly appBridge: VirtioBridge;
   private readonly network: QemuNetworkBackend | null;
 
   private tcpStreams = new Map<number, TcpForwardStream>();
@@ -178,6 +180,7 @@ export class SandboxServer extends EventEmitter {
     { resolve: () => void; reject: (err: Error) => void }
   >();
   private nextIngressTcpStreamId = 1;
+  private appStream: AppStream | null = null;
   private readonly baseAppend: string;
   private vfsProvider: SandboxVfsProvider | null;
   private fsService: FsRpcService | null = null;
@@ -310,6 +313,7 @@ export class SandboxServer extends EventEmitter {
       virtioFsSocketPath: this.options.virtioFsSocketPath,
       virtioSshSocketPath: this.options.virtioSshSocketPath,
       virtioIngressSocketPath: this.options.virtioIngressSocketPath,
+      virtioAppSocketPath: this.options.virtioAppSocketPath,
       netSocketPath: this.options.netEnabled
         ? this.options.netSocketPath
         : undefined,
@@ -351,6 +355,11 @@ export class SandboxServer extends EventEmitter {
     // Ingress proxy streams can also be long-lived and high-throughput.
     this.ingressBridge = new VirtioBridge(
       this.options.virtioIngressSocketPath,
+      Math.max(maxPendingBytes, 64 * 1024 * 1024),
+    );
+    // App channel is long-lived and carries guest daemon protocol traffic.
+    this.appBridge = new VirtioBridge(
+      this.options.virtioAppSocketPath,
       Math.max(maxPendingBytes, 64 * 1024 * 1024),
     );
     this.fsService = this.vfsProvider
@@ -396,6 +405,7 @@ export class SandboxServer extends EventEmitter {
         this.fsBridge.connect();
         this.sshBridge.connect();
         this.ingressBridge.connect();
+        this.appBridge.connect();
       }
       if (state === "stopped") {
         // The controller emits state="stopped" before emitting "exit".
@@ -886,6 +896,41 @@ export class SandboxServer extends EventEmitter {
         stream.destroy(new Error("ingress virtio bridge error"));
       }
       this.ingressTcpStreams.clear();
+    };
+
+    this.appBridge.onMessage = (message: any) => {
+      if (this.hasDebug("protocol")) {
+        const id = isValidRequestId(message.id) ? message.id : "?";
+        const extra =
+          message.t === "app_data"
+            ? ` bytes=${Buffer.isBuffer((message as any).p?.data) ? (message as any).p.data.length : 0}`
+            : "";
+        this.emitDebug(
+          "protocol",
+          `virtioapp rx t=${message.t} id=${id}${extra}`,
+        );
+      }
+
+      if (!isValidRequestId(message.id)) return;
+      if (message.t !== "app_data") return;
+      const data = (message as any).p?.data;
+      if (!Buffer.isBuffer(data)) return;
+      this.appStream?.pushRemote(data);
+    };
+
+    this.appBridge.onConnected = () => {
+      this.appStream?.markConnected();
+    };
+
+    this.appBridge.onDisconnected = () => {
+      this.appStream?.markDisconnected();
+    };
+
+    this.appBridge.onError = (err) => {
+      const message = err instanceof Error ? err.message : "unknown error";
+      this.emit("error", new Error(`[app] virtio bridge error: ${message}`));
+      this.appStream?.destroy(new Error(`app virtio bridge error: ${message}`));
+      this.appStream = null;
     };
 
     this.bridge.onError = (err) => {

--- a/host/src/sandbox/virtio-protocol.ts
+++ b/host/src/sandbox/virtio-protocol.ts
@@ -193,6 +193,20 @@ export type FileReadData = {
   };
 };
 
+export type AppData = {
+  /** protocol version */
+  v: number;
+  /** message type */
+  t: "app_data";
+  /** stream id */
+  id: number;
+  /** payload */
+  p: {
+    /** raw app channel bytes */
+    data: Buffer;
+  };
+};
+
 export type FileReadDone = {
   /** protocol version */
   v: number;
@@ -254,6 +268,7 @@ export type IncomingMessage =
   | TcpData
   | TcpEof
   | TcpClose
+  | AppData
   | FileReadData
   | FileReadDone
   | FileWriteDone

--- a/host/src/vm/core.ts
+++ b/host/src/vm/core.ts
@@ -196,6 +196,16 @@ export type SshAccess = {
   close(): Promise<void>;
 };
 
+export type AppChannelEvent = "reconnect" | "disconnect";
+
+export type AppChannel = {
+  /** bidirectional byte stream to/from the guest app daemon */
+  stream: Duplex;
+  /** subscribe to channel lifecycle events */
+  on(event: AppChannelEvent, callback: () => void): () => void;
+  /** close this handle */
+  close(): Promise<void>;
+};
 export type VMState = SandboxState | "unknown";
 
 type RootDiskState = {
@@ -264,6 +274,7 @@ export class VM {
   private gondolinEtc: ReturnType<typeof createGondolinEtcMount> | null = null;
   private ingressAccess: IngressAccess | null = null;
   private sessionIpc: SessionIpcServer | null = null;
+  private appChannel: AppChannel | null = null;
 
   /**
    * Create a VM instance, downloading guest assets if needed.
@@ -1064,6 +1075,95 @@ fi
     return access;
   }
 
+  /**
+   * Open the dedicated VM app channel.
+   */
+  async openAppChannel(): Promise<AppChannel> {
+    if (this.appChannel && !this.appChannel.stream.destroyed) {
+      return this.appChannel;
+    }
+    this.appChannel = null;
+
+    await this.start();
+
+    const server = this.server;
+    if (!server) {
+      throw new Error("sandbox server is not available");
+    }
+
+    const stream = server.openAppStream();
+    const reconnectHandlers = new Set<() => void>();
+    const disconnectHandlers = new Set<() => void>();
+    let hasConnectedAtLeastOnce = false;
+
+    const onConnected = () => {
+      if (hasConnectedAtLeastOnce) {
+        for (const callback of reconnectHandlers) {
+          try {
+            callback();
+          } catch {
+            // ignore subscriber errors
+          }
+        }
+      } else {
+        hasConnectedAtLeastOnce = true;
+      }
+    };
+
+    const onDisconnected = () => {
+      if (!hasConnectedAtLeastOnce) {
+        return;
+      }
+      for (const callback of disconnectHandlers) {
+        try {
+          callback();
+        } catch {
+          // ignore subscriber errors
+        }
+      }
+    };
+
+    stream.on("connected", onConnected);
+    stream.on("disconnected", onDisconnected);
+
+    if (stream.isConnected()) {
+      hasConnectedAtLeastOnce = true;
+    }
+
+    const channel: AppChannel = {
+      stream,
+      on: (event, callback) => {
+        if (event === "reconnect") {
+          reconnectHandlers.add(callback);
+          return () => {
+            reconnectHandlers.delete(callback);
+          };
+        }
+        disconnectHandlers.add(callback);
+        return () => {
+          disconnectHandlers.delete(callback);
+        };
+      },
+      close: async () => {
+        stream.off("connected", onConnected);
+        stream.off("disconnected", onDisconnected);
+        reconnectHandlers.clear();
+        disconnectHandlers.clear();
+        this.appChannel = null;
+        stream.destroy();
+      },
+    };
+
+    stream.once("close", () => {
+      if (this.appChannel === channel) {
+        this.appChannel = null;
+      }
+    });
+
+    this.appChannel = channel;
+    return channel;
+  }
+
   private execInternal(command: ExecInput, options: ExecOptions): ExecProcess {
     const { cmd, argv } = normalizeCommand(command, options);
     const id = this.allocateId();
@@ -1390,7 +1490,15 @@ fi
     if (!keepSessionRegistration) {
       unregisterSession(this.id);
     }
-
+    if (this.appChannel) {
+      try {
+        await this.appChannel.close();
+      } catch {
+        // ignore
+      } finally {
+        this.appChannel = null;
+      }
+    }
     if (this.ingressAccess) {
       try {
         await this.ingressAccess.close();

--- a/host/test/sandbox-controller.test.ts
+++ b/host/test/sandbox-controller.test.ts
@@ -38,6 +38,7 @@ function makeConfig(overrides?: Partial<SandboxConfig>): SandboxConfig {
     virtioFsSocketPath: "/tmp/virtiofs.sock",
     virtioSshSocketPath: "/tmp/virtio-ssh.sock",
     virtioIngressSocketPath: "/tmp/virtio-ingress.sock",
+    virtioAppSocketPath: "/tmp/virtio-app.sock",
     append: "console=ttyS0",
     machineType: "virt",
     accel: "tcg",
@@ -237,6 +238,8 @@ test("sandbox-controller: buildQemuArgs does not select -cpu host when using tcg
     virtioSocketPath: "/tmp/virtio.sock",
     virtioFsSocketPath: "/tmp/virtiofs.sock",
     virtioSshSocketPath: "/tmp/virtiossh.sock",
+    virtioIngressSocketPath: "/tmp/virtioingress.sock",
+    virtioAppSocketPath: "/tmp/virtioapp.sock",
     append: "console=ttyS0",
     machineType: "q35",
     accel: "tcg",
@@ -248,6 +251,9 @@ test("sandbox-controller: buildQemuArgs does not select -cpu host when using tcg
   const cpuIndex = args.indexOf("-cpu");
   assert.notEqual(cpuIndex, -1);
   assert.equal(args[cpuIndex + 1], "max");
+  assert.ok(args.includes("socket,id=virtioapp0,path=/tmp/virtioapp.sock,server=off"));
+  assert.ok(args.includes(`${"virtio-serial-pci"},id=virtio-serial0`));
+  assert.ok(args.includes("virtserialport,chardev=virtioapp0,name=virtio-app,bus=virtio-serial0.0"));
 });
 
 test("sandbox-controller: selectCpu only uses host with matching hw accel", () => {

--- a/host/test/sandbox-server-exit-diagnostics.test.ts
+++ b/host/test/sandbox-server-exit-diagnostics.test.ts
@@ -23,6 +23,8 @@ function makeResolvedOptions(
     virtioSocketPath: "/tmp/gondolin-test-virtio.sock",
     virtioFsSocketPath: "/tmp/gondolin-test-virtiofs.sock",
     virtioSshSocketPath: "/tmp/gondolin-test-virtiossh.sock",
+    virtioIngressSocketPath: "/tmp/gondolin-test-virtioingress.sock",
+    virtioAppSocketPath: "/tmp/gondolin-test-virtioapp.sock",
     netSocketPath: "/tmp/gondolin-test-net.sock",
     netMac: "02:00:00:00:00:01",
     netEnabled: false,

--- a/host/test/sandbox-server-queueing.test.ts
+++ b/host/test/sandbox-server-queueing.test.ts
@@ -23,6 +23,8 @@ function makeResolvedOptions(
     virtioSocketPath: "/tmp/gondolin-test-virtio.sock",
     virtioFsSocketPath: "/tmp/gondolin-test-virtiofs.sock",
     virtioSshSocketPath: "/tmp/gondolin-test-virtiossh.sock",
+    virtioIngressSocketPath: "/tmp/gondolin-test-virtioingress.sock",
+    virtioAppSocketPath: "/tmp/gondolin-test-virtioapp.sock",
     netSocketPath: "/tmp/gondolin-test-net.sock",
     netMac: "02:00:00:00:00:01",
     netEnabled: false,

--- a/host/test/vm-internals.test.ts
+++ b/host/test/vm-internals.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import test from "node:test";
 
 import { MemoryProvider, type VirtualProvider } from "../src/vfs/node/index.ts";
@@ -32,6 +33,7 @@ function makeTempResolvedServerOptions() {
       virtioFsSocketPath: path.join(dir, "virtiofs.sock"),
       virtioSshSocketPath: path.join(dir, "virtio-ssh.sock"),
       virtioIngressSocketPath: path.join(dir, "virtio-ingress.sock"),
+      virtioAppSocketPath: path.join(dir, "virtio-app.sock"),
       netSocketPath: path.join(dir, "net.sock"),
       netMac: "02:00:00:00:00:01",
       netEnabled: false,
@@ -677,6 +679,36 @@ test("vm internals: handleDisconnect rejects pending state waiters and sessions"
     await assert.rejects(waiter, /bye/);
     await assert.rejects(session1.resultPromise, /bye/);
     await assert.rejects(session2.resultPromise, /bye/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("vm internals: openAppChannel recreates channel after stream is destroyed", async () => {
+  const { vm, cleanup } = makeVm({ vfs: null });
+  try {
+    let openCount = 0;
+    const newStream = () => {
+      const stream = new PassThrough() as PassThrough & { isConnected: () => boolean };
+      stream.isConnected = () => true;
+      return stream;
+    };
+
+    (vm as any).start = async () => {};
+    (vm as any).server = {
+      openAppStream: () => {
+        openCount += 1;
+        return newStream();
+      },
+    };
+
+    const first = await vm.openAppChannel();
+    first.stream.destroy();
+
+    const second = await vm.openAppChannel();
+
+    assert.notEqual(first, second);
+    assert.equal(openCount, 2);
   } finally {
     cleanup();
   }


### PR DESCRIPTION
Basically adds an additional virtio channel that a user can use to exchange abritrary messages with the host

I am opening this as a discussion if something like this is aligned with what gondolin aims to be. Right now i use it for longer running things and i need a communication channel back and fourth. This seemed like a reasoanble way to do it and i could not think of a better way

Thoughts?

---

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
