### PR TITLE
fix(http): re-inject WebSocket headers stripped by WHATWG Request in applyRequestHooks

### DIFF
--- a/host/src/qemu/http.ts
+++ b/host/src/qemu/http.ts
@@ -64,6 +64,21 @@ const HTTP_STREAMING_RX_PAUSE_LOW_WATER_BYTES = 256 * 1024;
 // Keep this bounded separately from maxHttpBodyBytes.
 const MAX_HTTP_CHUNKED_OVERHEAD_BYTES = 256 * 1024;
 
+/**
+ * WebSocket upgrade headers that the WHATWG Fetch spec's forbidden
+ * request-header name list silently strips from `new Request()`.
+ * These must be re-injected after `applyRequestHooks` so the
+ * upstream handshake succeeds.
+ */
+const WEBSOCKET_UPGRADE_HEADER_NAMES = [
+  "connection",
+  "upgrade",
+  "sec-websocket-key",
+  "sec-websocket-version",
+  "sec-websocket-protocol",
+  "sec-websocket-extensions",
+] as const;
+
 type FetchResponse = Awaited<ReturnType<typeof undiciFetch>>;
 
 export type HttpSession = {
@@ -1720,6 +1735,15 @@ async function handleWebSocketUpgrade(
   }
 
   const hookRequest = requestHooked.request;
+
+  // Re-inject WebSocket headers stripped by the WHATWG Request constructor
+  // in applyRequestHooks (see WEBSOCKET_UPGRADE_HEADER_NAMES).
+  for (const h of WEBSOCKET_UPGRADE_HEADER_NAMES) {
+    if (baseRequest.headers[h] !== undefined && !(h in hookRequest.headers)) {
+      hookRequest.headers[h] = baseRequest.headers[h]!;
+    }
+  }
+
   const requestPolicyNeedsRecheck =
     !policyPrechecked ||
     hasPolicyRelevantRequestHeadChange(baseRequest, hookRequest);

--- a/host/test/qemu-net.test.ts
+++ b/host/test/qemu-net.test.ts
@@ -2357,6 +2357,133 @@ test("qemu-net: websocket upgrade prechecked request policy runs once", async ()
   }
 });
 
+test("qemu-net: websocket upgrade preserves headers when onRequest hook is set", async () => {
+  // Regression test: createHttpHooks sets an onRequest hook which converts the
+  // request to a WHATWG Request object. The Fetch spec's forbidden-header-name
+  // list silently strips connection, upgrade, sec-websocket-* headers. Without
+  // the re-injection fix, the upstream server receives a plain GET and rejects
+  // the upgrade.
+
+  const receivedHeaders: Record<string, string> = {};
+  const server = net.createServer((sock) => {
+    let buf = Buffer.alloc(0);
+    sock.on("data", (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      const idx = buf.indexOf("\r\n\r\n");
+      if (idx === -1) return;
+
+      // Parse and record the headers the server actually received
+      const head = buf.subarray(0, idx).toString("latin1");
+      const lines = head.split("\r\n");
+      for (let i = 1; i < lines.length; i++) {
+        const colon = lines[i].indexOf(":");
+        if (colon === -1) continue;
+        const name = lines[i].slice(0, colon).trim().toLowerCase();
+        const value = lines[i].slice(colon + 1).trim();
+        receivedHeaders[name] = value;
+      }
+
+      // Validate WebSocket upgrade headers are present
+      if (
+        receivedHeaders["upgrade"]?.toLowerCase() === "websocket" &&
+        receivedHeaders["sec-websocket-key"]
+      ) {
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            "\r\n",
+        );
+        sock.write(Buffer.from("ws-ok"));
+      } else {
+        sock.write(
+          "HTTP/1.1 400 Bad Request\r\n" +
+            "Content-Length: 24\r\n" +
+            "\r\n" +
+            "missing upgrade headers\n",
+        );
+      }
+      sock.end();
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  assert.ok(addr && typeof addr !== "string");
+
+  const { httpHooks } = createHttpHooks({
+    allowedHosts: ["example.com"],
+    blockInternalRanges: false,
+  });
+
+  const backend = makeBackend({
+    httpHooks,
+    allowWebSockets: true,
+  });
+
+  backend.options.dnsLookup = dnsLookupStub([
+    { address: "127.0.0.1", family: 4 },
+  ]);
+
+  const key = "TCP:1.1.1.1:1234:2.2.2.2:80";
+  const session: any = {
+    socket: null,
+    srcIP: "1.1.1.1",
+    srcPort: 1234,
+    dstIP: "2.2.2.2",
+    dstPort: 80,
+    connectIP: "2.2.2.2",
+    flowControlPaused: false,
+    protocol: "http",
+    connected: false,
+    pendingWrites: [],
+    pendingWriteBytes: 0,
+  };
+
+  backend.tcpSessions.set(key, session);
+
+  const writes: Buffer[] = [];
+  const req = Buffer.from(
+    "GET /chat HTTP/1.1\r\n" +
+      `Host: example.com:${addr.port}\r\n` +
+      "Connection: Upgrade\r\n" +
+      "Upgrade: websocket\r\n" +
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+      "Sec-WebSocket-Version: 13\r\n" +
+      "\r\n",
+  );
+
+  try {
+    await qemuHttp.handleHttpDataWithWriter(backend, key, session, req, {
+      scheme: "http",
+      write: (chunk: Buffer) => writes.push(Buffer.from(chunk)),
+      finish: () => {},
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const out = Buffer.concat(writes).toString("utf8");
+
+    // The server should receive the upgrade headers and respond with 101
+    assert.match(out, /^HTTP\/1\.1 101 /);
+    assert.ok(out.includes("ws-ok"));
+
+    // Verify the server actually received the critical WebSocket headers
+    assert.equal(receivedHeaders["upgrade"], "websocket");
+    assert.equal(receivedHeaders["connection"], "Upgrade");
+    assert.equal(
+      receivedHeaders["sec-websocket-key"],
+      "dGhlIHNhbXBsZSBub25jZQ==",
+    );
+    assert.equal(receivedHeaders["sec-websocket-version"], "13");
+  } finally {
+    try {
+      await backend.close();
+    } catch {}
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
 test("qemu-net: websocket upstream connect timeout covers stalled tls handshake", async () => {
   const serverSockets: net.Socket[] = [];
   const server = net.createServer((sock) => {


### PR DESCRIPTION
Fixes #82

## Summary

- Re-injects WebSocket-specific headers (`connection`, `upgrade`, `sec-websocket-*`) from `baseRequest` into `hookRequest` after `applyRequestHooks` returns in `handleWebSocketUpgrade`
- Only fills headers that were stripped (doesn't overwrite if present)
- Runs before policy recheck, preserving security invariants
- Added regression test that validates upstream server receives all WebSocket headers when `createHttpHooks` is used

## Why this happens

`applyRequestHooks` converts to a WHATWG `Request` object via `new Request(url, { headers })`. The Fetch spec's forbidden request-header name list silently strips `connection`, `upgrade`, and all `sec-websocket-*` headers. The existing WebSocket upgrade tests pass because they either don't set `onRequest` (skipping the WHATWG conversion) or their test servers accept upgrades without validating headers.

## Test plan

- [x] New test: "websocket upgrade preserves headers when onRequest hook is set" — starts a local server that **validates** WebSocket upgrade headers and only responds 101 if they're present
- [x] All 6 existing WebSocket tests pass
- [x] Verified end-to-end: both native WebSocket (Node 24) and `ws` library connect through Gondolin MITM proxy to `ws.postman-echo.com` with this fix

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.