### PR TITLE
fix(guest): drain TCP socket before closing on POLL.HUP in ingress forwarder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ guest/fuzz/out/
 guest/fuzz/out-native/
 guest/fuzz/cache/
 node_modules/
+.pnpm-store/
 host/node_modules/
 host/dist/
 host/var/

--- a/guest/src/root.zig
+++ b/guest/src/root.zig
@@ -7,3 +7,11 @@ pub const tcp_forwarder = @import("shared/tcp_forwarder.zig");
 pub const std_options = .{
     .log_level = .info,
 };
+
+test {
+    _ = cbor;
+    _ = protocol;
+    _ = request_path;
+    _ = fs_rpc;
+    _ = tcp_forwarder;
+}

--- a/guest/src/shared/tcp_forwarder.zig
+++ b/guest/src/shared/tcp_forwarder.zig
@@ -135,7 +135,7 @@ pub fn run(virtio_port_name: []const u8, log: anytype) !void {
                         if (conns.getPtr(data.id)) |conn| {
                             if (conn.pending.items.len + data.data.len > MAX_BUFFERED_TCP) {
                                 // Too much queued, close.
-                                closeConn(allocator, &conns, &writer, data.id);
+                                try closeConn(allocator, &conns, &writer, data.id);
                                 continue;
                             }
                             try conn.pending.appendSlice(allocator, data.data);
@@ -152,7 +152,7 @@ pub fn run(virtio_port_name: []const u8, log: anytype) !void {
                         }
                     },
                     .close => |id| {
-                        closeConn(allocator, &conns, &writer, id);
+                        try closeConn(allocator, &conns, &writer, id);
                     },
                 }
             }
@@ -171,24 +171,29 @@ pub fn run(virtio_port_name: []const u8, log: anytype) !void {
                 const n = std.posix.write(conn_ptr.fd, conn_ptr.pending.items) catch |err| blk: {
                     if (err == error.WouldBlock) break :blk @as(usize, 0);
                     // Remote closed
-                    closeConn(allocator, &conns, &writer, id);
+                    try closeConn(allocator, &conns, &writer, id);
                     break :blk @as(usize, 0);
                 };
+
+                const active_conn = conns.getPtr(id) orelse continue;
+
                 if (n > 0) {
-                    const remaining = conn_ptr.pending.items.len - n;
-                    std.mem.copyForwards(u8, conn_ptr.pending.items[0..remaining], conn_ptr.pending.items[n..]);
-                    conn_ptr.pending.items = conn_ptr.pending.items[0..remaining];
+                    const remaining = active_conn.pending.items.len - n;
+                    std.mem.copyForwards(u8, active_conn.pending.items[0..remaining], active_conn.pending.items[n..]);
+                    active_conn.pending.items = active_conn.pending.items[0..remaining];
                 }
 
-                if (conn_ptr.pending.items.len == 0 and conn_ptr.host_eof and !conn_ptr.backend_shutdown) {
-                    conn_ptr.backend_shutdown = true;
-                    _ = std.posix.shutdown(conn_ptr.fd, .send) catch {};
+                if (active_conn.pending.items.len == 0 and active_conn.host_eof and !active_conn.backend_shutdown) {
+                    active_conn.backend_shutdown = true;
+                    _ = std.posix.shutdown(active_conn.fd, .send) catch {};
                 }
             }
 
             if ((revents & (std.posix.POLL.IN | std.posix.POLL.HUP)) != 0) {
+                const should_drain_backend = (revents & std.posix.POLL.HUP) != 0;
+
                 while (writer.pendingBytes() < MAX_BUFFERED_VIRTIO) {
-                    switch (forwardBackendReadChunk(
+                    switch (try forwardBackendReadChunk(
                         allocator,
                         &conns,
                         &writer,
@@ -198,7 +203,9 @@ pub fn run(virtio_port_name: []const u8, log: anytype) !void {
                         conn_ptr.fd,
                         buffer[0..],
                     )) {
-                        .forwarded => continue,
+                        .forwarded => {
+                            if (!should_drain_backend) break;
+                        },
                         .would_block, .closed => break,
                     }
                 }
@@ -216,18 +223,18 @@ fn forwardBackendReadChunk(
     id: u32,
     backend_fd: std.posix.fd_t,
     buffer: []u8,
-) BackendReadResult {
+) !BackendReadResult {
     const n = std.posix.read(backend_fd, buffer) catch |err| {
         if (err == error.WouldBlock) return .would_block;
-        closeConn(allocator, conns, writer, id);
+        try closeConn(allocator, conns, writer, id);
         return .closed;
     };
     if (n == 0) {
-        closeConn(allocator, conns, writer, id);
+        try closeConn(allocator, conns, writer, id);
         return .closed;
     }
 
-    return forwardBackendPayload(allocator, conns, writer, virtio_fd, log, id, buffer[0..n]);
+    return try forwardBackendPayload(allocator, conns, writer, virtio_fd, log, id, buffer[0..n]);
 }
 
 fn forwardBackendPayload(
@@ -238,17 +245,17 @@ fn forwardBackendPayload(
     log: anytype,
     id: u32,
     payload_bytes: []const u8,
-) BackendReadResult {
+) !BackendReadResult {
     const payload = protocol.encodeTcpData(allocator, id, payload_bytes) catch |err| {
         log.err("encode tcp_data failed: {s}", .{@errorName(err)});
-        closeConn(allocator, conns, writer, id);
+        try closeConn(allocator, conns, writer, id);
         return .closed;
     };
     defer allocator.free(payload);
 
     writer.enqueue(payload) catch |err| {
         log.err("virtio enqueue failed: {s}", .{@errorName(err)});
-        closeConn(allocator, conns, writer, id);
+        try closeConn(allocator, conns, writer, id);
         return .closed;
     };
     writer.flush(virtio_fd) catch |err| {
@@ -262,15 +269,15 @@ fn closeConn(
     conns: *std.AutoHashMap(u32, Conn),
     writer: *protocol.FrameWriter,
     id: u32,
-) void {
+) !void {
     if (conns.fetchRemove(id)) |entry| {
         std.posix.close(entry.value.fd);
         var pending = entry.value.pending;
         pending.deinit(allocator);
 
-        const payload = protocol.encodeTcpClose(allocator, id) catch return;
+        const payload = try protocol.encodeTcpClose(allocator, id);
         defer allocator.free(payload);
-        writer.enqueue(payload) catch return;
+        try writer.enqueue(payload);
     }
 }
 
@@ -279,7 +286,7 @@ test "forwardBackendPayload closes connection when encoding fails after read" {
         fn err(_: @This(), comptime _: []const u8, _: anytype) void {}
     }{};
 
-    var allocator_bytes: [1024]u8 = undefined;
+    var allocator_bytes: [4096]u8 = undefined;
     var fixed_buffer_allocator = std.heap.FixedBufferAllocator.init(&allocator_bytes);
     const allocator = fixed_buffer_allocator.allocator();
 
@@ -307,7 +314,7 @@ test "forwardBackendPayload closes connection when encoding fails after read" {
     });
 
     const payload = [_]u8{0xaa} ** 8192;
-    const result = forwardBackendPayload(
+    const result = try forwardBackendPayload(
         allocator,
         &conns,
         &writer,
@@ -319,6 +326,52 @@ test "forwardBackendPayload closes connection when encoding fails after read" {
 
     try std.testing.expectEqual(BackendReadResult.closed, result);
     try std.testing.expect(conns.getPtr(7) == null);
+}
+
+test "forwardBackendPayload propagates close failure when tcp_close cannot be encoded" {
+    const silent_log = struct {
+        fn err(_: @This(), comptime _: []const u8, _: anytype) void {}
+    }{};
+
+    var failing_allocator_state = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const allocator = failing_allocator_state.allocator();
+
+    var writer = protocol.FrameWriter.init(allocator);
+    defer writer.deinit();
+
+    var conns = std.AutoHashMap(u32, Conn).init(allocator);
+    defer {
+        var it = conns.iterator();
+        while (it.next()) |entry| {
+            std.posix.close(entry.value_ptr.fd);
+            entry.value_ptr.pending.deinit(allocator);
+        }
+        conns.deinit();
+    }
+
+    const pipe_fds = try std.posix.pipe2(.{ .CLOEXEC = true, .NONBLOCK = true });
+    defer std.posix.close(pipe_fds[1]);
+
+    try conns.put(9, .{
+        .fd = pipe_fds[0],
+        .pending = .empty,
+        .host_eof = false,
+        .backend_shutdown = false,
+    });
+
+    failing_allocator_state.fail_index = failing_allocator_state.alloc_index;
+
+    const payload = [_]u8{0xbb} ** 8192;
+    try std.testing.expectError(error.OutOfMemory, forwardBackendPayload(
+        allocator,
+        &conns,
+        &writer,
+        pipe_fds[1],
+        silent_log,
+        9,
+        payload[0..],
+    ));
+    try std.testing.expect(conns.getPtr(9) == null);
 }
 
 fn handleOpen(
@@ -335,7 +388,7 @@ fn handleOpen(
     }
 
     // Close existing
-    closeConn(allocator, conns, writer, open.id);
+    try closeConn(allocator, conns, writer, open.id);
 
     const addr = try std.net.Address.parseIp("127.0.0.1", open.port);
     const stream = std.net.tcpConnectToAddress(addr) catch |err| {

--- a/guest/src/shared/tcp_forwarder.zig
+++ b/guest/src/shared/tcp_forwarder.zig
@@ -11,6 +11,12 @@ const protocol = @import("protocol.zig");
 const MAX_BUFFERED_VIRTIO: usize = 256 * 1024;
 const MAX_BUFFERED_TCP: usize = 256 * 1024;
 
+const BackendReadResult = enum {
+    would_block,
+    forwarded,
+    closed,
+};
+
 const Conn = struct {
     fd: std.posix.fd_t,
     /// pending bytes to write to tcp socket
@@ -180,34 +186,75 @@ pub fn run(virtio_port_name: []const u8, log: anytype) !void {
                 }
             }
 
-            if ((revents & std.posix.POLL.IN) != 0) {
-                const n = std.posix.read(conn_ptr.fd, buffer[0..]) catch |err| blk: {
-                    if (err == error.WouldBlock) break :blk @as(usize, 0);
-                    closeConn(allocator, &conns, &writer, id);
-                    break :blk @as(usize, 0);
-                };
-                if (n == 0) {
-                    closeConn(allocator, &conns, &writer, id);
-                } else if (n > 0) {
-                    const payload = protocol.encodeTcpData(allocator, id, buffer[0..n]) catch |err| {
-                        log.err("encode tcp_data failed: {s}", .{@errorName(err)});
-                        continue;
-                    };
-                    defer allocator.free(payload);
-                    writer.enqueue(payload) catch |err| {
-                        log.err("virtio enqueue failed: {s}", .{@errorName(err)});
-                        closeConn(allocator, &conns, &writer, id);
-                        continue;
-                    };
-                    writer.flush(virtio_fd) catch {};
+            if ((revents & (std.posix.POLL.IN | std.posix.POLL.HUP)) != 0) {
+                while (writer.pendingBytes() < MAX_BUFFERED_VIRTIO) {
+                    switch (forwardBackendReadChunk(
+                        allocator,
+                        &conns,
+                        &writer,
+                        virtio_fd,
+                        log,
+                        id,
+                        conn_ptr.fd,
+                        buffer[0..],
+                    )) {
+                        .forwarded => continue,
+                        .would_block, .closed => break,
+                    }
                 }
-            }
-
-            if ((revents & std.posix.POLL.HUP) != 0) {
-                closeConn(allocator, &conns, &writer, id);
             }
         }
     }
+}
+
+fn forwardBackendReadChunk(
+    allocator: std.mem.Allocator,
+    conns: *std.AutoHashMap(u32, Conn),
+    writer: *protocol.FrameWriter,
+    virtio_fd: std.posix.fd_t,
+    log: anytype,
+    id: u32,
+    backend_fd: std.posix.fd_t,
+    buffer: []u8,
+) BackendReadResult {
+    const n = std.posix.read(backend_fd, buffer) catch |err| {
+        if (err == error.WouldBlock) return .would_block;
+        closeConn(allocator, conns, writer, id);
+        return .closed;
+    };
+    if (n == 0) {
+        closeConn(allocator, conns, writer, id);
+        return .closed;
+    }
+
+    return forwardBackendPayload(allocator, conns, writer, virtio_fd, log, id, buffer[0..n]);
+}
+
+fn forwardBackendPayload(
+    allocator: std.mem.Allocator,
+    conns: *std.AutoHashMap(u32, Conn),
+    writer: *protocol.FrameWriter,
+    virtio_fd: std.posix.fd_t,
+    log: anytype,
+    id: u32,
+    payload_bytes: []const u8,
+) BackendReadResult {
+    const payload = protocol.encodeTcpData(allocator, id, payload_bytes) catch |err| {
+        log.err("encode tcp_data failed: {s}", .{@errorName(err)});
+        closeConn(allocator, conns, writer, id);
+        return .closed;
+    };
+    defer allocator.free(payload);
+
+    writer.enqueue(payload) catch |err| {
+        log.err("virtio enqueue failed: {s}", .{@errorName(err)});
+        closeConn(allocator, conns, writer, id);
+        return .closed;
+    };
+    writer.flush(virtio_fd) catch |err| {
+        log.err("virtio flush failed for conn {d}: {s}", .{ id, @errorName(err) });
+    };
+    return .forwarded;
 }
 
 fn closeConn(
@@ -225,6 +272,49 @@ fn closeConn(
         defer allocator.free(payload);
         writer.enqueue(payload) catch return;
     }
+}
+
+test "forwardBackendPayload closes connection when encoding fails after read" {
+    var allocator_bytes: [1024]u8 = undefined;
+    var fixed_buffer_allocator = std.heap.FixedBufferAllocator.init(&allocator_bytes);
+    const allocator = fixed_buffer_allocator.allocator();
+
+    var writer = protocol.FrameWriter.init(allocator);
+    defer writer.deinit();
+
+    var conns = std.AutoHashMap(u32, Conn).init(allocator);
+    defer {
+        var it = conns.iterator();
+        while (it.next()) |entry| {
+            std.posix.close(entry.value_ptr.fd);
+            entry.value_ptr.pending.deinit(allocator);
+        }
+        conns.deinit();
+    }
+
+    const pipe_fds = try std.posix.pipe2(.{ .CLOEXEC = true, .NONBLOCK = true });
+    defer std.posix.close(pipe_fds[1]);
+
+    try conns.put(7, .{
+        .fd = pipe_fds[0],
+        .pending = .empty,
+        .host_eof = false,
+        .backend_shutdown = false,
+    });
+
+    const payload = [_]u8{0xaa} ** 8192;
+    const result = forwardBackendPayload(
+        allocator,
+        &conns,
+        &writer,
+        pipe_fds[1],
+        std.log.scoped(.tcp_forwarder_test),
+        7,
+        payload[0..],
+    );
+
+    try std.testing.expectEqual(BackendReadResult.closed, result);
+    try std.testing.expect(conns.getPtr(7) == null);
 }
 
 fn handleOpen(

--- a/guest/src/shared/tcp_forwarder.zig
+++ b/guest/src/shared/tcp_forwarder.zig
@@ -275,6 +275,10 @@ fn closeConn(
 }
 
 test "forwardBackendPayload closes connection when encoding fails after read" {
+    const silent_log = struct {
+        fn err(_: @This(), comptime _: []const u8, _: anytype) void {}
+    }{};
+
     var allocator_bytes: [1024]u8 = undefined;
     var fixed_buffer_allocator = std.heap.FixedBufferAllocator.init(&allocator_bytes);
     const allocator = fixed_buffer_allocator.allocator();
@@ -308,7 +312,7 @@ test "forwardBackendPayload closes connection when encoding fails after read" {
         &conns,
         &writer,
         pipe_fds[1],
-        std.log.scoped(.tcp_forwarder_test),
+        silent_log,
         7,
         payload[0..],
     );

--- a/host/test/ingress-large-response.test.ts
+++ b/host/test/ingress-large-response.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import test from "node:test";
+
+import { VM } from "../src/vm/core.ts";
+import {
+  scheduleForceExit,
+  shouldSkipVmTests,
+} from "./helpers/vm-fixture.ts";
+
+const skipVmTests = shouldSkipVmTests();
+const timeoutMs = Number(process.env.WS_TIMEOUT ?? 120000);
+const ingressFetchTimeoutMs = 5000;
+const payloadSizeBytes = 900_000;
+const repoGuestAssetsDir = path.resolve(
+  import.meta.dirname,
+  "..",
+  "..",
+  "guest",
+  "image",
+  "out",
+);
+const missingRepoGuestAssetsReason =
+  !fs.existsSync(path.join(repoGuestAssetsDir, "manifest.json"))
+    ? "repo guest assets missing (run make build or make -C guest assets)"
+    : false;
+
+type CapturedHttpResponse = {
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer;
+  complete: boolean;
+  aborted: boolean;
+  responseErrorMessage: string | null;
+};
+
+function buildDeterministicPayload(length: number): Buffer {
+  const payload = Buffer.allocUnsafe(length);
+  for (let index = 0; index < payload.length; index += 1) {
+    payload[index] = (index * 31) % 251;
+  }
+  return payload;
+}
+
+function sha256Hex(buffer: Buffer): string {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+async function fetchCapturedHttpResponse(
+  targetUrl: URL,
+): Promise<CapturedHttpResponse> {
+  return await new Promise<CapturedHttpResponse>((resolve, reject) => {
+    const request = http.get(targetUrl, (response) => {
+      const chunks: Buffer[] = [];
+      let aborted = false;
+      let responseErrorMessage: string | null = null;
+
+      response.on("data", (chunk: Buffer | string) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      response.once("aborted", () => {
+        aborted = true;
+      });
+      response.once("error", (error) => {
+        responseErrorMessage = error.message;
+      });
+      response.once("close", () => {
+        resolve({
+          statusCode: response.statusCode ?? 0,
+          headers: response.headers,
+          body: Buffer.concat(chunks),
+          complete: response.complete,
+          aborted,
+          responseErrorMessage,
+        });
+      });
+    });
+
+    request.setTimeout(ingressFetchTimeoutMs, () => {
+      request.destroy(new Error("timed out waiting for ingress response"));
+    });
+    request.once("error", (error) => {
+      reject(error);
+    });
+  });
+}
+
+async function waitForGuestHttpServer(
+  vm: VM,
+  expectedBodyLength: number,
+): Promise<void> {
+  let lastStdout = "";
+  let lastStderr = "";
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const probe = await vm.exec([
+      "/bin/sh",
+      "-lc",
+      [
+        "rm -f /tmp/ingress-large-probe.bin",
+        "busybox wget -qO /tmp/ingress-large-probe.bin http://127.0.0.1:18080/asset.bin",
+        "wc -c < /tmp/ingress-large-probe.bin",
+      ].join("; "),
+    ]);
+
+    lastStdout = probe.stdout.trim();
+    lastStderr = probe.stderr.trim();
+    if (probe.exitCode === 0 && lastStdout === String(expectedBodyLength)) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(
+    `guest http server never served the expected payload (stdout=${JSON.stringify(lastStdout)}, stderr=${JSON.stringify(lastStderr)})`,
+  );
+}
+
+async function resolveGuestHttpServerLaunchCommand(vm: VM): Promise<string | null> {
+  const probe = await vm.exec([
+    "/bin/sh",
+    "-lc",
+    [
+      "if command -v python3 >/dev/null 2>&1; then",
+      "  echo 'python3 -m http.server 18080 --bind 127.0.0.1 --directory /tmp/ingress-large-www';",
+      "elif command -v python >/dev/null 2>&1; then",
+      "  echo 'python -m http.server 18080 --bind 127.0.0.1 --directory /tmp/ingress-large-www';",
+      "elif busybox --list 2>/dev/null | grep -qx httpd; then",
+      "  echo 'busybox httpd -f -p 127.0.0.1:18080 -h /tmp/ingress-large-www';",
+      "else",
+      "  exit 1;",
+      "fi",
+    ].join(" "),
+  ]);
+
+  if (probe.exitCode !== 0) {
+    return null;
+  }
+
+  return probe.stdout.trim() || null;
+}
+
+test.after(() => {
+  scheduleForceExit();
+});
+
+test(
+  "enableIngress forwards full large fixed-length responses",
+  {
+    skip: skipVmTests || missingRepoGuestAssetsReason,
+    timeout: timeoutMs,
+  },
+  async (t) => {
+    const vm = await VM.create({
+      sandbox: {
+        console: "none",
+        imagePath: repoGuestAssetsDir,
+      },
+    });
+
+    let access: Awaited<ReturnType<VM["enableIngress"]>> | null = null;
+    t.after(async () => {
+      if (access) {
+        await access.close();
+      }
+
+      try {
+        await vm.exec([
+          "/bin/sh",
+          "-lc",
+          "kill $(cat /tmp/ingress-large-httpd.pid) >/dev/null 2>&1 || true",
+        ]);
+      } catch {
+        // best-effort cleanup
+      }
+
+      await vm.close();
+    });
+
+    await vm.start();
+
+    const guestHttpServerLaunchCommand =
+      await resolveGuestHttpServerLaunchCommand(vm);
+    if (!guestHttpServerLaunchCommand) {
+      t.skip("guest image does not include a supported local HTTP server");
+      return;
+    }
+
+    const payload = buildDeterministicPayload(payloadSizeBytes);
+    const expectedDigest = sha256Hex(payload);
+
+    await vm.fs.mkdir("/tmp/ingress-large-www", { recursive: true });
+    await vm.fs.writeFile("/tmp/ingress-large-www/asset.bin", payload);
+
+    const launch = await vm.exec([
+      "/bin/sh",
+      "-lc",
+      [
+        `${guestHttpServerLaunchCommand} >/tmp/ingress-large-httpd.log 2>&1 & pid=$!`,
+        "echo $pid > /tmp/ingress-large-httpd.pid",
+      ].join("; "),
+    ]);
+    assert.equal(
+      launch.exitCode,
+      0,
+      launch.stderr || "failed to launch ingress httpd",
+    );
+
+    await waitForGuestHttpServer(vm, payload.length);
+
+    vm.setIngressRoutes([{ prefix: "/", port: 18080, stripPrefix: true }]);
+    access = await vm.enableIngress();
+
+    let response: CapturedHttpResponse | null = null;
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      try {
+        response = await fetchCapturedHttpResponse(
+          new URL("/asset.bin", access.url),
+        );
+        if (response.statusCode === 200) {
+          break;
+        }
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    if (!response && lastError) {
+      throw lastError;
+    }
+
+    assert.ok(response, "expected ingress response");
+    assert.equal(
+      response.statusCode,
+      200,
+      `unexpected ingress status with ${response.body.length} bytes received`,
+    );
+    assert.equal(response.headers["content-length"], String(payload.length));
+    assert.equal(response.aborted, false, "response should not abort");
+    assert.equal(response.complete, true, "response should complete cleanly");
+    assert.equal(
+      response.responseErrorMessage,
+      null,
+      "response should not emit an error",
+    );
+    assert.equal(
+      response.body.length,
+      payload.length,
+      "ingress should deliver every response byte",
+    );
+    assert.equal(
+      sha256Hex(response.body),
+      expectedDigest,
+      "ingress response body should match the guest payload",
+    );
+  },
+);

--- a/host/test/ingress-large-response.test.ts
+++ b/host/test/ingress-large-response.test.ts
@@ -28,6 +28,11 @@ const missingRepoGuestAssetsReason =
     ? "repo guest assets missing (run make build or make -C guest assets)"
     : false;
 
+type GuestHttpServerSpec = {
+  launchCommand: string;
+  readinessCommand: string;
+};
+
 type CapturedHttpResponse = {
   statusCode: number;
   headers: http.IncomingHttpHeaders;
@@ -90,6 +95,7 @@ async function fetchCapturedHttpResponse(
 
 async function waitForGuestHttpServer(
   vm: VM,
+  readinessCommand: string,
   expectedBodyLength: number,
 ): Promise<void> {
   let lastStdout = "";
@@ -99,11 +105,7 @@ async function waitForGuestHttpServer(
     const probe = await vm.exec([
       "/bin/sh",
       "-lc",
-      [
-        "rm -f /tmp/ingress-large-probe.bin",
-        "busybox wget -qO /tmp/ingress-large-probe.bin http://127.0.0.1:18080/asset.bin",
-        "wc -c < /tmp/ingress-large-probe.bin",
-      ].join("; "),
+      readinessCommand,
     ]);
 
     lastStdout = probe.stdout.trim();
@@ -120,17 +122,19 @@ async function waitForGuestHttpServer(
   );
 }
 
-async function resolveGuestHttpServerLaunchCommand(vm: VM): Promise<string | null> {
+async function resolveGuestHttpServer(
+  vm: VM,
+): Promise<GuestHttpServerSpec | null> {
   const probe = await vm.exec([
     "/bin/sh",
     "-lc",
     [
       "if command -v python3 >/dev/null 2>&1; then",
-      "  echo 'python3 -m http.server 18080 --bind 127.0.0.1 --directory /tmp/ingress-large-www';",
+      "  echo python3;",
       "elif command -v python >/dev/null 2>&1; then",
-      "  echo 'python -m http.server 18080 --bind 127.0.0.1 --directory /tmp/ingress-large-www';",
-      "elif busybox --list 2>/dev/null | grep -qx httpd; then",
-      "  echo 'busybox httpd -f -p 127.0.0.1:18080 -h /tmp/ingress-large-www';",
+      "  echo python;",
+      "elif busybox --list 2>/dev/null | grep -qx httpd && busybox --list 2>/dev/null | grep -qx wget; then",
+      "  echo busybox;",
       "else",
       "  exit 1;",
       "fi",
@@ -141,7 +145,37 @@ async function resolveGuestHttpServerLaunchCommand(vm: VM): Promise<string | nul
     return null;
   }
 
-  return probe.stdout.trim() || null;
+  const serverKind = probe.stdout.trim();
+  if (serverKind === "python3") {
+    return {
+      launchCommand:
+        "python3 -m http.server 18080 --bind 127.0.0.1 --directory /tmp/ingress-large-www",
+      readinessCommand: [
+        "python3 -c 'import sys, urllib.request; data = urllib.request.urlopen(\"http://127.0.0.1:18080/asset.bin\").read(); sys.stdout.write(str(len(data)))'",
+      ].join(" "),
+    };
+  }
+
+  if (serverKind === "python") {
+    return {
+      launchCommand:
+        "python -m http.server 18080 --bind 127.0.0.1 --directory /tmp/ingress-large-www",
+      readinessCommand: [
+        "python -c 'import sys, urllib.request; data = urllib.request.urlopen(\"http://127.0.0.1:18080/asset.bin\").read(); sys.stdout.write(str(len(data)))'",
+      ].join(" "),
+    };
+  }
+
+  if (serverKind === "busybox") {
+    return {
+      launchCommand:
+        "busybox httpd -f -p 127.0.0.1:18080 -h /tmp/ingress-large-www",
+      readinessCommand:
+        "busybox wget -qO - http://127.0.0.1:18080/asset.bin | wc -c",
+    };
+  }
+
+  throw new Error(`unexpected guest http server kind: ${JSON.stringify(serverKind)}`);
 }
 
 test.after(() => {
@@ -183,12 +217,11 @@ test(
 
     await vm.start();
 
-    const guestHttpServerLaunchCommand =
-      await resolveGuestHttpServerLaunchCommand(vm);
-    if (!guestHttpServerLaunchCommand) {
-      t.skip("guest image does not include a supported local HTTP server");
-      return;
-    }
+    const guestHttpServer = await resolveGuestHttpServer(vm);
+    assert.ok(
+      guestHttpServer,
+      "guest image does not include a supported local HTTP server",
+    );
 
     const payload = buildDeterministicPayload(payloadSizeBytes);
     const expectedDigest = sha256Hex(payload);
@@ -200,7 +233,7 @@ test(
       "/bin/sh",
       "-lc",
       [
-        `${guestHttpServerLaunchCommand} >/tmp/ingress-large-httpd.log 2>&1 & pid=$!`,
+        `${guestHttpServer.launchCommand} >/tmp/ingress-large-httpd.log 2>&1 & pid=$!`,
         "echo $pid > /tmp/ingress-large-httpd.pid",
       ].join("; "),
     ]);
@@ -210,7 +243,11 @@ test(
       launch.stderr || "failed to launch ingress httpd",
     );
 
-    await waitForGuestHttpServer(vm, payload.length);
+    await waitForGuestHttpServer(
+      vm,
+      guestHttpServer.readinessCommand,
+      payload.length,
+    );
 
     vm.setIngressRoutes([{ prefix: "/", port: 18080, stripPrefix: true }]);
     access = await vm.enableIngress();


### PR DESCRIPTION
## Summary

This PR is now a follow-up to the original ingress truncation fix that already landed on `main`.

It keeps the remaining hardening and verification work:

- close the connection if `encodeTcpData()` fails after bytes were already read from the backend socket, so we do not silently drop already-consumed data
- log `writer.flush()` failures in the ingress forwarder instead of swallowing them
- wire guest inline Zig tests into the root guest test binary so they actually run in the VM-backed guest test path
- keep the stronger end-to-end large-response regression test that boots the repo-built guest image and verifies full-body delivery with byte-count and SHA-256 checks


## Why

`main` already contains the core `POLL.HUP` fix for issue #86. During review, we validated that there was still another silent-loss path in the same forwarder:

- if the backend socket `read()` succeeds
- but `encodeTcpData()` then fails
- the bytes have already left the kernel buffer
- returning as if nothing happened would silently lose data

This PR closes that gap and improves observability around forwarder flush failures.

## User and Developer Impact

- ingress forwarding is safer under allocation failure in the guest forwarder
- forwarder flush failures now leave diagnostics instead of disappearing silently
- the guest Zig test path now actually executes inline tests from imported shared modules
- the large-response ingress regression remains covered end-to-end in host tests

## Validation

- `make -C guest test` passes and now runs the guest inline Zig tests through the VM-backed guest test path
- `host/test/ingress-large-response.test.ts` passes
- `make check` passes
- `make test` passes

Fixes #86
