### PR TITLE
fix(http): separate secret scopes from global allowlist

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -64,13 +64,14 @@ Not substituted:
 Each secret has its own host pattern allowlist (`secrets.NAME.hosts`).  Patterns
 are case-insensitive and support `*` wildcards.
 
-`createHttpHooks` also builds the final network host allowlist as:
+`createHttpHooks` keeps the global network host allowlist separate from per-secret
+substitution scopes:
 
-- `allowedHosts` from options
-- plus all hosts referenced by `secrets.*.hosts`
+- `allowedHosts` controls global egress policy (`undefined` = allow all, explicit `[]` = deny all)
+- `secrets.*.hosts` only controls where that specific secret may be substituted
 
-So if you omit `allowedHosts` but define secrets, those secret host patterns are
-still added to the allowed host set.
+So configuring a secret does not narrow or expand the global host allowlist on
+its own.
 
 ## Hook Ordering
 

--- a/host/bin/gondolin.ts
+++ b/host/bin/gondolin.ts
@@ -5,6 +5,7 @@ import net from "net";
 import os from "os";
 import path from "path";
 import { PassThrough } from "stream";
+import { fileURLToPath } from "url";
 
 import { VmCheckpoint } from "../src/checkpoint.ts";
 import { VM } from "../src/vm/core.ts";
@@ -814,7 +815,8 @@ function buildVmOptions(common: CommonOptions) {
     }
 
     const result = createHttpHooks({
-      allowedHosts: common.allowedHosts,
+      allowedHosts:
+        common.allowedHosts.length > 0 ? common.allowedHosts : undefined,
       secrets,
     });
     httpHooks = result.httpHooks;
@@ -2875,7 +2877,25 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  renderCliError(err);
-  process.exit(1);
-});
+function isMainModule(moduleUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+
+  const entryPath = fs.realpathSync.native(path.resolve(entry));
+  const modulePath = fs.realpathSync.native(fileURLToPath(moduleUrl));
+  return entryPath === modulePath;
+}
+
+export const __test = {
+  buildVmOptions,
+  parseHostSecret,
+};
+
+if (isMainModule(import.meta.url)) {
+  main().catch((err) => {
+    renderCliError(err);
+    process.exit(1);
+  });
+}

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -17,7 +17,7 @@ export type SecretDefinition = {
 };
 
 export type CreateHttpHooksOptions = {
-  /** allowed host patterns (empty = allow all) */
+  /** allowed host patterns (omitted = allow all, explicit empty = deny all) */
   allowedHosts?: string[];
   /** host patterns allowed to resolve to internal ip ranges */
   allowedInternalHosts?: string[];
@@ -39,6 +39,33 @@ export type CreateHttpHooksOptions = {
   onResponse?: HttpHooks["onResponse"];
 };
 
+export type UpdateSecretOptions = {
+  /** updated secret value */
+  value?: string;
+  /** updated host patterns this secret may be sent to */
+  hosts?: string[];
+};
+
+export type SecretManagerEntry = {
+  /** env var name */
+  name: string;
+  /** guest-visible placeholder value */
+  placeholder: string;
+  /** allowed host patterns */
+  hosts: string[];
+  /** whether placeholder substitution yields an empty string */
+  deleted: boolean;
+};
+
+export type SecretManager = {
+  /** list configured secrets */
+  listSecrets(): SecretManagerEntry[];
+  /** update an existing secret */
+  updateSecret(name: string, options: UpdateSecretOptions): void;
+  /** replace an existing secret with an empty string */
+  deleteSecret(name: string): void;
+};
+
 export type CreateHttpHooksResult = {
   /** http hook implementation */
   httpHooks: HttpHooks;
@@ -46,44 +73,95 @@ export type CreateHttpHooksResult = {
   env: Record<string, string>;
   /** resolved allowed hosts */
   allowedHosts: string[];
+  /** runtime manager for configured secrets */
+  secretManager: SecretManager;
 };
 
 type SecretEntry = {
   name: string;
   placeholder: string;
   value: string;
+  revokedValues: string[];
   hosts: string[];
+  deleted: boolean;
 };
 
 export function createHttpHooks(
   options: CreateHttpHooksOptions = {},
 ): CreateHttpHooksResult {
   const env: Record<string, string> = {};
-  const secretEntries: SecretEntry[] = [];
   const blockInternalRanges = options.blockInternalRanges ?? true;
+  const configuredAllowedHosts =
+    options.allowedHosts === undefined ? ["*"] : uniqueHosts(options.allowedHosts);
+  const secretEntries = new Map<string, SecretEntry>();
 
   for (const [name, secret] of Object.entries(options.secrets ?? {})) {
     const placeholder = `GONDOLIN_SECRET_${crypto.randomBytes(24).toString("hex")}`;
     env[name] = placeholder;
-    secretEntries.push({
+    secretEntries.set(name, {
       name,
       placeholder,
       value: secret.value,
-      hosts: secret.hosts.map(normalizeHostnamePattern),
+      revokedValues: [],
+      hosts: uniqueHosts(secret.hosts),
+      deleted: false,
     });
   }
 
   const allowedInternalHosts = uniqueHosts(options.allowedInternalHosts ?? []);
+  const allowedHosts = mergeAllowedHosts(
+    configuredAllowedHosts,
+    allowedInternalHosts,
+  );
 
-  const allowedHosts = uniqueHosts([
-    ...(options.allowedHosts ?? []),
-    ...allowedInternalHosts,
-    ...secretEntries.flatMap((entry) => entry.hosts),
-  ]);
+  const getSecretEntries = (): SecretEntry[] => Array.from(secretEntries.values());
+
+  const getSecretEntry = (name: string): SecretEntry => {
+    const entry = secretEntries.get(name);
+    if (!entry) {
+      throw new Error(`unknown secret: ${name}`);
+    }
+    return entry;
+  };
+
+  const secretManager: SecretManager = {
+    listSecrets() {
+      return getSecretEntries().map((entry) => ({
+        name: entry.name,
+        placeholder: entry.placeholder,
+        hosts: [...entry.hosts],
+        deleted: entry.deleted,
+      }));
+    },
+    updateSecret(name, update) {
+      const entry = getSecretEntry(name);
+      if (entry.deleted) {
+        throw new Error(`secret deleted: ${name}`);
+      }
+      if (update.hosts !== undefined) {
+        entry.hosts = uniqueHosts(update.hosts);
+      }
+      if (update.value !== undefined && update.value !== entry.value) {
+        entry.revokedValues = addUniqueString(entry.revokedValues, entry.value);
+        entry.value = update.value;
+        entry.revokedValues = entry.revokedValues.filter(
+          (value) => value !== entry.value,
+        );
+      }
+    },
+    deleteSecret(name) {
+      const entry = getSecretEntry(name);
+      if (entry.deleted) {
+        return;
+      }
+      entry.deleted = true;
+    },
+  };
 
   const applySecretsToRequest = (request: Request): Request => {
     assertRequestShape(request);
     const hostname = getHostname(request.url);
+    const entries = getSecretEntries();
 
     // Defense-in-depth: if the request already contains real secret values (eg: because
     // it was constructed from a redirected hop), make sure we still enforce per-secret
@@ -91,19 +169,19 @@ export function createHttpHooks(
     assertSecretValuesAllowedForHost(
       request,
       hostname,
-      secretEntries,
+      entries,
       options.replaceSecretsInQuery ?? false,
     );
 
     const headers = replaceSecretPlaceholdersInHeaders(
       request.headers,
       hostname,
-      secretEntries,
+      entries,
     );
     const url = replaceSecretPlaceholdersInUrlParameters(
       request.url,
       hostname,
-      secretEntries,
+      entries,
       options.replaceSecretsInQuery ?? false,
     );
 
@@ -152,9 +230,10 @@ export function createHttpHooks(
       return true;
     },
     isIpAllowed: async (info) => {
-      const hostnameAllowedByHostList =
-        allowedHosts.length === 0 ||
-        matchesAnyHost(info.hostname, allowedHosts);
+      const hostnameAllowedByHostList = matchesAnyHost(
+        info.hostname,
+        allowedHosts,
+      );
       if (!hostnameAllowedByHostList) {
         return false;
       }
@@ -176,7 +255,7 @@ export function createHttpHooks(
     onResponse: options.onResponse,
   };
 
-  return { httpHooks, env, allowedHosts };
+  return { httpHooks, env, allowedHosts, secretManager };
 }
 
 function cloneRequestWith(
@@ -280,17 +359,46 @@ function assertSecretValuesAllowedForHost(
   if (entries.length === 0) return;
 
   for (const entry of entries) {
+    if (
+      requestContainsSecretValuesInHeaders(request.headers, entry.revokedValues) ||
+      (checkQuery &&
+        requestContainsSecretValuesInQuery(request.url, entry.revokedValues))
+    ) {
+      throw new HttpRequestBlockedError(
+        `secret ${entry.name} revoked for host: ${hostname || "unknown"}`,
+      );
+    }
+
+    if (entry.deleted) {
+      if (requestContainsSecretValuesInHeaders(request.headers, [entry.value])) {
+        throw new HttpRequestBlockedError(
+          `secret ${entry.name} deleted for host: ${hostname || "unknown"}`,
+        );
+      }
+
+      if (
+        checkQuery &&
+        requestContainsSecretValuesInQuery(request.url, [entry.value])
+      ) {
+        throw new HttpRequestBlockedError(
+          `secret ${entry.name} deleted for host: ${hostname || "unknown"}`,
+        );
+      }
+
+      continue;
+    }
+
     // If the destination is allowed for this secret, we don't care whether the secret
     // value already appears in the request.
     if (matchesAnyHost(hostname, entry.hosts)) continue;
 
-    if (requestContainsSecretValueInHeaders(request.headers, entry)) {
+    if (requestContainsSecretValuesInHeaders(request.headers, [entry.value])) {
       throw new HttpRequestBlockedError(
         `secret ${entry.name} not allowed for host: ${hostname || "unknown"}`,
       );
     }
 
-    if (checkQuery && requestContainsSecretValueInQuery(request.url, entry)) {
+    if (checkQuery && requestContainsSecretValuesInQuery(request.url, [entry.value])) {
       throw new HttpRequestBlockedError(
         `secret ${entry.name} not allowed for host: ${hostname || "unknown"}`,
       );
@@ -298,25 +406,28 @@ function assertSecretValuesAllowedForHost(
   }
 }
 
-function requestContainsSecretValueInHeaders(
+function requestContainsSecretValuesInHeaders(
   headers: Headers,
-  entry: SecretEntry,
+  values: string[],
 ): boolean {
-  if (!entry.value) return false;
+  const nonEmptyValues = values.filter(Boolean);
+  if (nonEmptyValues.length === 0) return false;
 
   for (const [headerName, headerValue] of headers.entries()) {
     if (!headerValue) continue;
 
-    // Plaintext match (eg: Authorization: Bearer <token>)
-    if (headerValue.includes(entry.value)) {
-      return true;
-    }
-
-    // Basic auth uses base64 encoding
-    if (/^(authorization|proxy-authorization)$/i.test(headerName)) {
-      const decoded = decodeBasicAuth(headerValue);
-      if (decoded && decoded.includes(entry.value)) {
+    for (const value of nonEmptyValues) {
+      // Plaintext match (eg: Authorization: Bearer <token>)
+      if (headerValue.includes(value)) {
         return true;
+      }
+
+      // Basic auth uses base64 encoding
+      if (/^(authorization|proxy-authorization)$/i.test(headerName)) {
+        const decoded = decodeBasicAuth(headerValue);
+        if (decoded && decoded.includes(value)) {
+          return true;
+        }
       }
     }
   }
@@ -336,11 +447,12 @@ function decodeBasicAuth(value: string): string | null {
   }
 }
 
-function requestContainsSecretValueInQuery(
+function requestContainsSecretValuesInQuery(
   url: string,
-  entry: SecretEntry,
+  values: string[],
 ): boolean {
-  if (!entry.value) return false;
+  const nonEmptyValues = values.filter(Boolean);
+  if (nonEmptyValues.length === 0) return false;
 
   let parsed: URL;
   try {
@@ -352,8 +464,10 @@ function requestContainsSecretValueInQuery(
   if (!parsed.search) return false;
 
   for (const [name, value] of parsed.searchParams.entries()) {
-    if (name.includes(entry.value) || value.includes(entry.value)) {
-      return true;
+    for (const secretValue of nonEmptyValues) {
+      if (name.includes(secretValue) || value.includes(secretValue)) {
+        return true;
+      }
     }
   }
 
@@ -483,6 +597,11 @@ function replaceSecretPlaceholdersInString(
 
   for (const entry of entries) {
     if (!updated.includes(entry.placeholder)) continue;
+    if (entry.deleted) {
+      updated = replaceAll(updated, entry.placeholder, "");
+      continue;
+    }
+
     assertSecretAllowedForHost(entry, hostname);
     updated = replaceAll(updated, entry.placeholder, entry.value);
   }
@@ -555,6 +674,24 @@ function uniqueHosts(hosts: string[]): string[] {
   }
 
   return result;
+}
+
+function mergeAllowedHosts(
+  configuredAllowedHosts: string[],
+  allowedInternalHosts: string[],
+): string[] {
+  if (configuredAllowedHosts.includes("*")) {
+    return ["*"];
+  }
+
+  return uniqueHosts([...configuredAllowedHosts, ...allowedInternalHosts]);
+}
+
+function addUniqueString(values: string[], value: string): string[] {
+  if (!value || values.includes(value)) {
+    return values;
+  }
+  return [...values, value];
 }
 
 function replaceAll(

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -360,9 +360,17 @@ function assertSecretValuesAllowedForHost(
 
   for (const entry of entries) {
     if (
-      requestContainsSecretValuesInHeaders(request.headers, entry.revokedValues) ||
+      requestContainsRevokedOrDeletedSecretValuesInHeaders(
+        request.headers,
+        entry.revokedValues,
+        entry.deleted ? [] : [entry.value],
+      ) ||
       (checkQuery &&
-        requestContainsSecretValuesInQuery(request.url, entry.revokedValues))
+        requestContainsRevokedOrDeletedSecretValuesInQuery(
+          request.url,
+          entry.revokedValues,
+          entry.deleted ? [] : [entry.value],
+        ))
     ) {
       throw new HttpRequestBlockedError(
         `secret ${entry.name} revoked for host: ${hostname || "unknown"}`,
@@ -370,7 +378,13 @@ function assertSecretValuesAllowedForHost(
     }
 
     if (entry.deleted) {
-      if (requestContainsSecretValuesInHeaders(request.headers, [entry.value])) {
+      if (
+        requestContainsRevokedOrDeletedSecretValuesInHeaders(
+          request.headers,
+          [entry.value],
+          [],
+        )
+      ) {
         throw new HttpRequestBlockedError(
           `secret ${entry.name} deleted for host: ${hostname || "unknown"}`,
         );
@@ -378,7 +392,11 @@ function assertSecretValuesAllowedForHost(
 
       if (
         checkQuery &&
-        requestContainsSecretValuesInQuery(request.url, [entry.value])
+        requestContainsRevokedOrDeletedSecretValuesInQuery(
+          request.url,
+          [entry.value],
+          [],
+        )
       ) {
         throw new HttpRequestBlockedError(
           `secret ${entry.name} deleted for host: ${hostname || "unknown"}`,
@@ -435,6 +453,60 @@ function requestContainsSecretValuesInHeaders(
   return false;
 }
 
+function requestContainsRevokedOrDeletedSecretValuesInHeaders(
+  headers: Headers,
+  forbiddenValues: string[],
+  allowedValues: string[],
+): boolean {
+  const nonEmptyForbiddenValues = forbiddenValues.filter(Boolean);
+  const nonEmptyAllowedValues = allowedValues.filter(Boolean);
+  if (nonEmptyForbiddenValues.length === 0) return false;
+
+  for (const [headerName, headerValue] of headers.entries()) {
+    if (!headerValue) continue;
+
+    if (/^(authorization|proxy-authorization)$/i.test(headerName)) {
+      const decoded = decodeBasicAuthStrict(headerValue);
+      if (decoded) {
+        if (
+          containsForbiddenValueOutsideAllowedRanges(
+            decoded,
+            nonEmptyForbiddenValues,
+            nonEmptyAllowedValues,
+          )
+        ) {
+          return true;
+        }
+        continue;
+      }
+
+      if (
+        containsForbiddenValueOutsideAllowedRanges(
+          headerValue,
+          nonEmptyForbiddenValues,
+          nonEmptyAllowedValues,
+        )
+      ) {
+        return true;
+      }
+
+      continue;
+    }
+
+    if (
+      containsForbiddenValueOutsideAllowedRanges(
+        headerValue,
+        nonEmptyForbiddenValues,
+        nonEmptyAllowedValues,
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function decodeBasicAuth(value: string): string | null {
   const match = value.match(/^(Basic)(\s+)(\S+)(\s*)$/i);
   if (!match) return null;
@@ -445,6 +517,32 @@ function decodeBasicAuth(value: string): string | null {
   } catch {
     return null;
   }
+}
+
+function decodeBasicAuthStrict(value: string): string | null {
+  const match = value.match(/^(Basic)(\s+)(\S+)(\s*)$/i);
+  if (!match) return null;
+
+  const token = match[3];
+  if (!token || !/^[A-Za-z0-9+/]+={0,2}$/.test(token)) {
+    return null;
+  }
+
+  if (token.length % 4 === 1) {
+    return null;
+  }
+
+  const decoded = Buffer.from(token, "base64").toString("utf8");
+  const normalizedToken = stripBase64Padding(token);
+  const normalizedDecoded = stripBase64Padding(
+    Buffer.from(decoded, "utf8").toString("base64"),
+  );
+
+  if (normalizedDecoded !== normalizedToken) {
+    return null;
+  }
+
+  return decoded;
 }
 
 function requestContainsSecretValuesInQuery(
@@ -472,6 +570,92 @@ function requestContainsSecretValuesInQuery(
   }
 
   return false;
+}
+
+function requestContainsRevokedOrDeletedSecretValuesInQuery(
+  url: string,
+  forbiddenValues: string[],
+  allowedValues: string[],
+): boolean {
+  const nonEmptyForbiddenValues = forbiddenValues.filter(Boolean);
+  const nonEmptyAllowedValues = allowedValues.filter(Boolean);
+  if (nonEmptyForbiddenValues.length === 0) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (!parsed.search) return false;
+
+  for (const [name, value] of parsed.searchParams.entries()) {
+    if (
+      containsForbiddenValueOutsideAllowedRanges(
+        name,
+        nonEmptyForbiddenValues,
+        nonEmptyAllowedValues,
+      ) ||
+      containsForbiddenValueOutsideAllowedRanges(
+        value,
+        nonEmptyForbiddenValues,
+        nonEmptyAllowedValues,
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function containsForbiddenValueOutsideAllowedRanges(
+  container: string,
+  forbiddenValues: string[],
+  allowedValues: string[],
+): boolean {
+  if (!container) return false;
+
+  const allowedRanges = allowedValues.flatMap((value) =>
+    collectStringMatchRanges(container, value),
+  );
+
+  for (const forbiddenValue of forbiddenValues) {
+    for (const range of collectStringMatchRanges(container, forbiddenValue)) {
+      if (!isRangeCoveredByAllowedValue(range, allowedRanges)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function collectStringMatchRanges(
+  container: string,
+  search: string,
+): Array<{ start: number; end: number }> {
+  if (!search) return [];
+
+  const ranges: Array<{ start: number; end: number }> = [];
+  let start = container.indexOf(search);
+
+  while (start !== -1) {
+    ranges.push({ start, end: start + search.length });
+    start = container.indexOf(search, start + 1);
+  }
+
+  return ranges;
+}
+
+function isRangeCoveredByAllowedValue(
+  candidate: { start: number; end: number },
+  allowedRanges: Array<{ start: number; end: number }>,
+): boolean {
+  return allowedRanges.some(
+    (allowed) => allowed.start <= candidate.start && allowed.end >= candidate.end,
+  );
 }
 
 function replaceSecretPlaceholdersInHeaders(
@@ -660,6 +844,10 @@ function isPrivateIPv6(ip: string): boolean {
   if (mapped && isPrivateIPv4(mapped)) return true;
 
   return false;
+}
+
+function stripBase64Padding(value: string): string {
+  return value.replace(/=+$/g, "");
 }
 
 function uniqueHosts(hosts: string[]): string[] {

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -81,6 +81,9 @@ export {
   type CreateHttpHooksOptions,
   type CreateHttpHooksResult,
   type SecretDefinition,
+  type SecretManager,
+  type SecretManagerEntry,
+  type UpdateSecretOptions,
 } from "./http/hooks.ts";
 
 // Network types

--- a/host/test/cli-http-hooks-options.test.ts
+++ b/host/test/cli-http-hooks-options.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { __test } from "../bin/gondolin.ts";
+
+function makeCommonOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    mounts: [],
+    memoryMounts: [],
+    allowedHosts: [],
+    secrets: [],
+    dnsTrustedServers: [],
+    tcpHostMappings: {},
+    sshAllowedHosts: [],
+    sshCredentials: [],
+    sshAgent: undefined,
+    sshKnownHostsFiles: [],
+    ...overrides,
+  };
+}
+
+test("buildVmOptions keeps implicit open egress for host secrets without --allow-host", async () => {
+  const vmOptions = __test.buildVmOptions(
+    makeCommonOptions({
+      secrets: [
+        {
+          name: "API_KEY",
+          hosts: ["example.com"],
+          value: "secret-value",
+        },
+      ],
+    }) as any,
+  );
+
+  assert.ok(vmOptions.httpHooks);
+  assert.deepEqual(vmOptions.env, {
+    API_KEY: vmOptions.env.API_KEY,
+  });
+  assert.match(vmOptions.env.API_KEY, /^GONDOLIN_SECRET_/);
+  assert.equal(
+    await vmOptions.httpHooks.isIpAllowed({
+      hostname: "unrelated.example",
+      ip: "93.184.216.34",
+      family: 4,
+      port: 443,
+      protocol: "https",
+    }),
+    true,
+  );
+});
+
+test("buildVmOptions still honors explicit global allowlists", async () => {
+  const vmOptions = __test.buildVmOptions(
+    makeCommonOptions({
+      allowedHosts: ["api.example.com"],
+      secrets: [
+        {
+          name: "API_KEY",
+          hosts: ["example.com"],
+          value: "secret-value",
+        },
+      ],
+    }) as any,
+  );
+
+  assert.ok(vmOptions.httpHooks);
+  assert.equal(
+    await vmOptions.httpHooks.isIpAllowed({
+      hostname: "api.example.com",
+      ip: "93.184.216.34",
+      family: 4,
+      port: 443,
+      protocol: "https",
+    }),
+    true,
+  );
+  assert.equal(
+    await vmOptions.httpHooks.isIpAllowed({
+      hostname: "example.com",
+      ip: "93.184.216.34",
+      family: 4,
+      port: 443,
+      protocol: "https",
+    }),
+    false,
+  );
+});

--- a/host/test/cli-symlink-entry.test.ts
+++ b/host/test/cli-symlink-entry.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("cli: symlinked gondolin entry path still executes main", (t) => {
+  const hostDir = path.join(import.meta.dirname, "..");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-cli-symlink-"));
+  t.after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const targetPath = path.join(hostDir, "bin", "gondolin.ts");
+  const symlinkPath = path.join(tmpDir, "gondolin-link.ts");
+  fs.symlinkSync(targetPath, symlinkPath);
+
+  const result = spawnSync(
+    process.execPath,
+    [symlinkPath, "bash", "--help"],
+    {
+      cwd: hostDir,
+      env: process.env,
+      encoding: "utf8",
+      timeout: 15000,
+    },
+  );
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout ?? "", /--listen/);
+  assert.match(result.stdout ?? "", /--resume/);
+});

--- a/host/test/http-hooks.test.ts
+++ b/host/test/http-hooks.test.ts
@@ -210,7 +210,7 @@ test("http hooks allowedInternalHosts can bypass internal range block", async ()
     allowedInternalHosts: ["corp.example"],
   });
 
-  assert.deepEqual(allowedHosts, ["corp.example"]);
+  assert.deepEqual(allowedHosts, ["*"]);
 
   const isAllowed = httpHooks.isIpAllowed!;
 
@@ -451,7 +451,7 @@ test("http hooks replace secret placeholders", async () => {
     },
   });
 
-  assert.ok(allowedHosts.includes("example.com"));
+  assert.deepEqual(allowedHosts, ["*"]);
 
   const request = await runRequestHook(
     httpHooks.onRequest!,
@@ -465,6 +465,194 @@ test("http hooks replace secret placeholders", async () => {
   );
 
   assert.equal(request.headers.get("authorization"), "Bearer secret-value");
+});
+
+test("http hooks update existing secrets after creation", async () => {
+  const { httpHooks, env, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "secret-value",
+      },
+    },
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "rotated-value" });
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.com/data",
+      headers: {
+        authorization: `Bearer ${env.API_KEY}`,
+      },
+    }),
+  );
+
+  assert.equal(request.headers.get("authorization"), "Bearer rotated-value");
+});
+
+test("http hooks update secret host allowlists after creation", async () => {
+  const { httpHooks, env, allowedHosts, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "secret-value",
+      },
+    },
+  });
+
+  assert.deepEqual(allowedHosts, ["*"]);
+
+  secretManager.updateSecret("API_KEY", { hosts: ["example.org"] });
+
+  assert.deepEqual(allowedHosts, ["*"]);
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data",
+          headers: {
+            authorization: `Bearer ${env.API_KEY}`,
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.org/data",
+      headers: {
+        authorization: `Bearer ${env.API_KEY}`,
+      },
+    }),
+  );
+
+  assert.equal(request.headers.get("authorization"), "Bearer secret-value");
+});
+
+test("http hooks delete secrets by substituting empty strings", async () => {
+  const { httpHooks, env, allowedHosts, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "secret-value",
+      },
+    },
+  });
+
+  secretManager.deleteSecret("API_KEY");
+
+  assert.deepEqual(allowedHosts, ["*"]);
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.org/data",
+      headers: {
+        authorization: `Bearer ${env.API_KEY}`,
+      },
+    }),
+  );
+
+  assert.match(request.headers.get("authorization") ?? "", /^Bearer ?$/);
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.org/data",
+          headers: {
+            authorization: "Bearer secret-value",
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+});
+
+test("http hooks default global allowlist stays open when secrets are configured", async () => {
+  const { httpHooks, allowedHosts } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "secret-value",
+      },
+    },
+  });
+
+  assert.deepEqual(allowedHosts, ["*"]);
+
+  assert.equal(
+    await httpHooks.isIpAllowed!({
+      hostname: "unrelated.example",
+      ip: "93.184.216.34",
+      family: 4,
+      port: 443,
+      protocol: "https",
+    }),
+    true,
+  );
+});
+
+test("http hooks explicit empty allowlist denies all even when secrets exist", async () => {
+  const { httpHooks, allowedHosts } = createHttpHooks({
+    allowedHosts: [],
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "secret-value",
+      },
+    },
+  });
+
+  assert.deepEqual(allowedHosts, []);
+
+  assert.equal(
+    await httpHooks.isIpAllowed!({
+      hostname: "example.com",
+      ip: "93.184.216.34",
+      family: 4,
+      port: 443,
+      protocol: "https",
+    }),
+    false,
+  );
+});
+
+test("http hooks reject revoked secret values after rotation on allowed hosts", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "secret-value",
+      },
+    },
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "rotated-value" });
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data",
+          headers: {
+            authorization: "Bearer secret-value",
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
 });
 
 test("http hooks keep placeholders in URL parameters by default", async () => {

--- a/host/test/http-hooks.test.ts
+++ b/host/test/http-hooks.test.ts
@@ -655,6 +655,246 @@ test("http hooks reject revoked secret values after rotation on allowed hosts", 
   );
 });
 
+test("http hooks reject revoked secret values embedded in custom headers", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "oldsecret",
+      },
+    },
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "newsecret" });
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data",
+          headers: {
+            "x-api-key": "key=oldsecret",
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+});
+
+test("http hooks reject revoked secret values embedded in authorization headers", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "oldsecret",
+      },
+    },
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "newsecret" });
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data",
+          headers: {
+            authorization: "Bearer prefix-oldsecret-suffix",
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+});
+
+test("http hooks reject revoked secret values in malformed basic auth headers", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "oldsecret",
+      },
+    },
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "newsecret" });
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data",
+          headers: {
+            authorization: "Basic oldsecret",
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+});
+
+test("http hooks reject deleted secret values in malformed basic auth headers", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "oldsecret",
+      },
+    },
+  });
+
+  secretManager.deleteSecret("API_KEY");
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data",
+          headers: {
+            authorization: "Basic oldsecret",
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+});
+
+test("http hooks allow rotated secret values that contain revoked header values", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "abc",
+      },
+    },
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "abcd" });
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.com/data",
+      headers: {
+        authorization: "Bearer abcd",
+      },
+    }),
+  );
+
+  assert.equal(request.headers.get("authorization"), "Bearer abcd");
+});
+
+test("http hooks allow embedded current secret values that contain revoked header values", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "abc",
+      },
+    },
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "abcd" });
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.com/data",
+      headers: {
+        authorization: "Bearer prefix-abcd-suffix",
+      },
+    }),
+  );
+
+  assert.equal(
+    request.headers.get("authorization"),
+    "Bearer prefix-abcd-suffix",
+  );
+});
+
+test("http hooks allow rotated secret values that contain revoked query values", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "abc",
+      },
+    },
+    replaceSecretsInQuery: true,
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "abcd" });
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.com/data?token=abcd",
+    }),
+  );
+
+  assert.equal(new URL(request.url).searchParams.get("token"), "abcd");
+});
+
+test("http hooks reject revoked secret values embedded in query values", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "oldsecret",
+      },
+    },
+    replaceSecretsInQuery: true,
+  });
+
+  secretManager.updateSecret("API_KEY", { value: "newsecret" });
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data?sig=oldsecret-v2",
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+});
+
+test("http hooks reject deleted secret values embedded in headers and query values", async () => {
+  const { httpHooks, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "oldsecret",
+      },
+    },
+    replaceSecretsInQuery: true,
+  });
+
+  secretManager.deleteSecret("API_KEY");
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data?sig=prefix-oldsecret-suffix",
+          headers: {
+            "x-api-key": "prefix-oldsecret-suffix",
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+});
+
 test("http hooks keep placeholders in URL parameters by default", async () => {
   const { httpHooks, env } = createHttpHooks({
     secrets: {


### PR DESCRIPTION
Keep createHttpHooks global host policy independent from per-secret substitution scopes so installing HTTP hooks no longer narrows egress by default.

Also preserve revoked secret values across rotations so stale credentials continue to be blocked after a secret update.

Fixes #92 