### PR TITLE
Add CommonJS export

### DIFF
--- a/host/package.json
+++ b/host/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
+      "import": "./dist/src/index.js",
+      "require": "./dist/src/index.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/host/scripts/postbuild.mjs
+++ b/host/scripts/postbuild.mjs
@@ -56,6 +56,15 @@ export function copyGuestSources(pkgRoot, guestSourceRoot) {
   }
 }
 
+function writeCjsEntrypoint(pkgRoot) {
+  const entryPath = path.join(pkgRoot, "dist", "src", "index.cjs");
+  fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+  fs.writeFileSync(
+    entryPath,
+    '"use strict";\nmodule.exports = require("./index.js");\n',
+  );
+}
+
 function rewriteDeclarationsInDir(dirPath) {
   for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
     const fullPath = path.join(dirPath, entry.name);
@@ -107,6 +116,7 @@ export function runPostbuild({
   const distRoot = path.join(pkgRoot, "dist");
   if (fs.existsSync(distRoot)) {
     rewriteDeclarationsInDir(distRoot);
+    writeCjsEntrypoint(pkgRoot);
   }
 
   return { guestSourceRoot };

--- a/host/test/postbuild-script.test.ts
+++ b/host/test/postbuild-script.test.ts
@@ -75,6 +75,10 @@ test("postbuild: finds guest sources via GONDOLIN_GUEST_SRC", () => {
       fs.readFileSync(path.join(pkgRoot, "dist", "src", "index.d.ts"), "utf8"),
       'export { foo } from "./foo.js";\nexport type Bar = import("./bar.js").Bar;\n',
     );
+    assert.equal(
+      fs.readFileSync(path.join(pkgRoot, "dist", "src", "index.cjs"), "utf8"),
+      '"use strict";\nmodule.exports = require("./index.js");\n',
+    );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
CJS exports were inadvertently broken in https://github.com/earendil-works/gondolin/pull/62 (91c75fd)