### PR TITLE
Use setup-zig action in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Zig
-        run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install dependencies
         run: |
@@ -120,9 +120,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Zig
-        run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install dependencies
         run: pnpm install
@@ -183,9 +183,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Zig
-        run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -215,9 +215,9 @@ jobs:
           node-version: '24'
 
       - name: Install Zig
-        run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -278,9 +278,9 @@ jobs:
           touch guest/image/out/*
 
       - name: Install Zig
-        run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -351,9 +351,9 @@ jobs:
           touch guest/image/out/*
 
       - name: Install Zig
-        run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -159,9 +159,9 @@ jobs:
           cache: pnpm
 
       - name: Install Zig
-        run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,13 +76,9 @@ jobs:
           - runner: ubuntu-latest
             package_dir: packages/gondolin-krun-runner-linux-x64
             package_name: '@earendil-works/gondolin-krun-runner-linux-x64'
-            zig_archive: zig-x86_64-linux-0.16.0.tar.xz
-            zig_url: https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz
           - runner: macos-14
             package_dir: packages/gondolin-krun-runner-darwin-arm64
             package_name: '@earendil-works/gondolin-krun-runner-darwin-arm64'
-            zig_archive: zig-aarch64-macos-0.16.0.tar.xz
-            zig_url: https://ziglang.org/download/0.16.0/zig-aarch64-macos-0.16.0.tar.xz
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,11 +91,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install Zig
-        run: |
-          curl -L "${{ matrix.zig_url }}" | tar -xJ
-          ZIG_DIR="${{ matrix.zig_archive }}"
-          ZIG_DIR="${ZIG_DIR%.tar.xz}"
-          echo "$PWD/$ZIG_DIR" >> "$GITHUB_PATH"
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
This means we will cache binaries and most importantly download binaries from [community mirrors](https://ziglang.org/download/community-mirrors/) instead of only the Zig Foundation's website.