### PR TITLE
Use @earendil-works instead of @mariozechner for npm

### DIFF
--- a/host/examples/pi-gondolin.ts
+++ b/host/examples/pi-gondolin.ts
@@ -27,7 +27,7 @@ import path from "node:path";
 import type {
   ExtensionAPI,
   ExtensionContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
   type BashOperations,
   createBashTool,
@@ -37,7 +37,7 @@ import {
   type EditOperations,
   type ReadOperations,
   type WriteOperations,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 
 import { RealFSProvider, VM } from "@earendil-works/gondolin";
 


### PR DESCRIPTION
Change the NPM package references from `@mariozechner/pi-coding-agent` to `@earendil-works/pi-coding-agent
Provide a brief description of the changes in this PR here.

## Contribution Agreement

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
