### PR TITLE
Add runtime egress policy controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ npx @earendil-works/gondolin attach <session-id>
 # Snapshot a running session (stops it)
 npx @earendil-works/gondolin snapshot <session-id>
 
+# Disable outbound egress for a live session
+npx @earendil-works/gondolin network off <session-id>
+
 # Resume from snapshot id/path
 npx @earendil-works/gondolin bash --resume <snapshot-id-or-path>
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,7 @@ Gondolin ships with a small command line interface (CLI) that lets you:
 - list running VM sessions (`list`)
 - attach a new interactive command to an existing VM (`attach`)
 - snapshot a running VM session (`snapshot`)
+- inspect or change live session egress policy (`network`)
 - run one or more commands non-interactively (`exec`)
 - build and verify custom guest assets (`build`)
 - manage local image refs/objects (`image`)
@@ -364,6 +365,33 @@ gondolin snapshot 9e3a2e2d
 
 # Snapshot to an explicit path
 gondolin snapshot 9e3a2e2d --output ./my-snapshot.qcow2
+```
+
+### `gondolin network`
+
+Inspect or update runtime egress policy for a live VM session:
+
+```bash
+gondolin network <action> <SESSION_ID>
+```
+
+Actions:
+
+- `status` - print the current policy
+- `off` - block all VM-mediated guest-initiated host egress (DNS, web,
+  SSH, mapped TCP)
+- `on` - re-open the runtime egress gate (configured policies still apply)
+
+`off` closes existing egress sessions.
+
+Examples:
+
+```bash
+# Emergency cutoff: block VM-mediated outbound egress and close active sessions
+gondolin network off 9e3a2e2d
+
+# Re-open the runtime egress gate
+gondolin network on 9e3a2e2d
 ```
 
 ### `gondolin exec`

--- a/docs/network.md
+++ b/docs/network.md
@@ -253,6 +253,52 @@ To make this work, the guest must trust the host-generated CA:
 
 Policy enforcement happens on the host and is designed to be robust against common evasion tricks.
 
+### Runtime Egress Policy
+
+A live VM has a mutable, host-enforced runtime network policy:
+
+- `egress: "deny"` blocks all guest-initiated host egress, including DNS
+  forwarding, HTTP/HTTPS/WebSocket egress, optional SSH egress, and explicit
+  mapped TCP egress.
+
+The policy is enforced in the host network backend before creating new upstream
+host sockets. It does not rely on guest firewall state, so root inside the guest
+cannot turn it back on.
+
+SDK example:
+
+```ts
+const vm = await VM.create();
+
+// Hard cutoff: block every egress class and close active sessions.
+vm.setNetworkPolicy({ egress: "deny" });
+
+// Re-open the runtime egress gate.
+vm.setNetworkPolicy({ egress: "allow" });
+
+console.log(vm.getNetworkPolicy()); // { egress: "allow" }
+```
+
+CLI example for an existing session:
+
+```bash
+gondolin list
+gondolin network off <session-id>
+```
+
+Important semantics:
+
+- `egress: "deny"` is the security-oriented cutoff for VM-mediated
+  guest-initiated egress.
+- `egress: "allow"` re-opens the runtime gate; configured allowlists, hooks,
+  SSH/TCP mappings, and other network policy still apply.
+- Setting `egress: "deny"` closes existing affected sessions.
+- Host-to-guest control paths such as `exec`, `attach`, snapshots, VFS, and
+  ingress listeners are not guest-initiated egress and remain usable.
+- Host-side hook code is outside this VM egress path: if `onRequest` performs
+  its own `fetch()` or other network I/O, runtime egress policy does not
+  intercept that host-side I/O.
+
 ### Allowlist by Hostname
 
 A typical setup uses an allowlist of hostnames (often with `*` wildcards).

--- a/docs/sdk-network.md
+++ b/docs/sdk-network.md
@@ -89,6 +89,41 @@ Notable consequences:
   policy; the host enforces policy against the HTTP `Host` header and does its own
   resolution to prevent DNS rebinding attacks
 
+### Runtime Egress Switch
+
+You can change the host-enforced egress policy of a live VM without rebooting:
+
+```ts
+import { VM } from "@earendil-works/gondolin";
+
+const vm = await VM.create();
+
+// Emergency cutoff: block DNS, web, SSH egress, and mapped TCP.
+// Existing affected sessions are closed when egress is denied.
+vm.setOutboundEgressEnabled(false);
+
+// Equivalent lower-level form.
+vm.setNetworkPolicy({ egress: "deny" });
+
+// Re-open the runtime egress gate later.
+vm.setNetworkPolicy({ egress: "allow" });
+
+console.log(vm.getNetworkPolicy()); // { egress: "allow" }
+```
+
+Details:
+
+- `egress: "deny"` blocks all VM-mediated guest-initiated host egress and is
+  the exfiltration cutoff.
+- `egress: "allow"` re-opens the runtime gate; configured allowlists, hooks,
+  SSH/TCP mappings, and other network policy still apply.
+- Existing sessions affected by `egress: "deny"` are always closed.
+- Host-to-guest features (`exec`, `attach`, VFS, snapshots, ingress) remain
+  available because they are not guest-initiated outbound egress.
+- Host-side hook code is outside the VM egress path: if `onRequest` performs its
+  own `fetch()` or other network I/O, runtime egress policy does not intercept
+  that host-side I/O.
+
 For deeper conceptual background, see [Network stack](./network.md).
 
 ## Mapped TCP Egress (Optional)

--- a/docs/sdk-vm.md
+++ b/docs/sdk-vm.md
@@ -44,6 +44,19 @@ Advanced users can access the registry/attach helpers directly:
 - `gcSessions()`
 - `connectToSession()`
 
+## Runtime Network Policy
+
+A live VM's outbound egress can be changed without rebooting:
+
+```ts
+vm.setOutboundEgressEnabled(false); // block DNS, web, SSH, and mapped TCP egress
+vm.setNetworkPolicy({ egress: "allow" }); // re-open the runtime gate
+vm.getNetworkPolicy(); // { egress: "allow" }
+```
+
+See [SDK: Network Access](./sdk-network.md#runtime-egress-switch) for semantics
+and the CLI equivalent (`gondolin network`).
+
 ## `vm.exec()`
 
 This is the most common operation. It returns an `ExecProcess` (a running

--- a/host/README.md
+++ b/host/README.md
@@ -70,6 +70,9 @@ npx @earendil-works/gondolin attach <session-id>
 # Snapshot a running VM session (stops that session)
 npx @earendil-works/gondolin snapshot <session-id>
 
+# Disable outbound egress for a live session
+npx @earendil-works/gondolin network off <session-id>
+
 # Resume from snapshot id/path
 npx @earendil-works/gondolin bash --resume <snapshot-id-or-path>
 ```

--- a/host/bin/gondolin.ts
+++ b/host/bin/gondolin.ts
@@ -46,6 +46,7 @@ import {
 } from "../src/session-registry.ts";
 import {
   decodeOutputFrame,
+  type NetworkPolicyResponseMessage,
   type ServerMessage,
   type SnapshotResponseMessage,
 } from "../src/sandbox/control-protocol.ts";
@@ -218,6 +219,7 @@ function usage() {
   console.log("  list         List running VM sessions");
   console.log("  attach       Attach to a running VM session");
   console.log("  snapshot     Snapshot a running VM session");
+  console.log("  network      Inspect or change live session egress policy");
   console.log(
     "  build        Build custom guest assets (kernel, initramfs, rootfs)",
   );
@@ -385,6 +387,20 @@ function snapshotUsage() {
   );
   console.log("  --name NAME     Snapshot name (default output path only)");
   console.log("  --help, -h      Show this help");
+}
+
+function networkUsage() {
+  console.log("Usage: gondolin network <action> <SESSION_ID>");
+  console.log();
+  console.log("Inspect or update host-enforced runtime egress policy.");
+  console.log();
+  console.log("Actions:");
+  console.log("  status      Show current policy");
+  console.log("  off         Block VM-mediated guest-initiated host egress");
+  console.log("  on          Re-open the runtime egress gate");
+  console.log();
+  console.log("Options:");
+  console.log("  --help, -h  Show this help");
 }
 
 function execUsage() {
@@ -2370,6 +2386,135 @@ async function runSnapshot(argv: string[]) {
   }
 }
 
+type NetworkAction = "status" | "off" | "on";
+
+type NetworkArgs = {
+  action: NetworkAction;
+  sessionId: string;
+};
+
+function isNetworkAction(value: string): value is NetworkAction {
+  return value === "status" || value === "off" || value === "on";
+}
+
+function parseNetworkArgs(argv: string[]): NetworkArgs {
+  if (argv.length === 0) {
+    networkUsage();
+    process.exit(1);
+  }
+
+  let action: NetworkAction | undefined;
+  let sessionId = "";
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!;
+
+    if (arg === "--help" || arg === "-h") {
+      networkUsage();
+      process.exit(0);
+    }
+
+    if (!action && isNetworkAction(arg)) {
+      action = arg;
+      continue;
+    }
+
+    if (!sessionId && !arg.startsWith("-")) {
+      sessionId = arg;
+      continue;
+    }
+
+    console.error(`Unknown argument: ${arg}`);
+    networkUsage();
+    process.exit(1);
+  }
+
+  if (!action) {
+    console.error("network requires an action");
+    networkUsage();
+    process.exit(1);
+  }
+
+  if (!sessionId) {
+    console.error("network requires a session id");
+    networkUsage();
+    process.exit(1);
+  }
+
+  return { action, sessionId };
+}
+
+async function runNetwork(argv: string[]) {
+  const args = parseNetworkArgs(argv);
+
+  await gcSessions().catch(() => {
+    // ignore
+  });
+
+  const session = await findSession(args.sessionId);
+  if (!session || !session.alive) {
+    throw new Error(`session not found or not running: ${args.sessionId}`);
+  }
+
+  const requestId = 1;
+  let done = false;
+  let resolveDone!: (message: NetworkPolicyResponseMessage) => void;
+  let rejectDone!: (error: Error) => void;
+  const donePromise = new Promise<NetworkPolicyResponseMessage>(
+    (resolve, reject) => {
+      resolveDone = resolve;
+      rejectDone = reject;
+    },
+  );
+
+  const client = connectToSession(session.socketPath, {
+    onJson(message: ServerMessage) {
+      if (message.type === "status") return;
+
+      if (message.type === "network_policy_response") {
+        if (message.id !== requestId) return;
+        done = true;
+        resolveDone(message);
+        return;
+      }
+
+      if (message.type === "error") {
+        if (message.id !== undefined && message.id !== requestId) return;
+        done = true;
+        rejectDone(new Error(`error ${message.code}: ${message.message}`));
+      }
+    },
+    onBinary() {
+      // network command does not stream binary data
+    },
+    onClose(error?: Error) {
+      if (done) return;
+      done = true;
+      rejectDone(error ?? new Error("session connection closed"));
+    },
+  });
+
+  const policy =
+    args.action === "off"
+      ? { egress: "deny" as const }
+      : args.action === "on"
+        ? { egress: "allow" as const }
+        : undefined;
+
+  client.send({
+    type: "network_policy",
+    id: requestId,
+    policy,
+  });
+
+  try {
+    const result = await donePromise;
+    console.log(`egress: ${result.policy.egress}`);
+  } finally {
+    client.close();
+  }
+}
+
 // ============================================================================
 // Build command
 // ============================================================================
@@ -2923,6 +3068,9 @@ async function main() {
       return;
     case "snapshot":
       await runSnapshot(args);
+      return;
+    case "network":
+      await runNetwork(args);
       return;
     case "build":
       await runBuild(args);

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -10,6 +10,8 @@ export {
   VM,
   type VMOptions,
   type VMState,
+  type EffectiveNetworkPolicy,
+  type RuntimeNetworkPolicy,
   type EnableSshOptions,
   type SshAccess,
   type VmFs,
@@ -99,6 +101,7 @@ export {
 export type {
   DnsMode,
   DnsOptions,
+  NetworkPolicyAction,
   SyntheticDnsHostMappingMode,
   HttpIpAllowInfo,
   HttpHooks,

--- a/host/src/qemu/contracts.ts
+++ b/host/src/qemu/contracts.ts
@@ -76,6 +76,15 @@ export type HttpHooks = {
 
 export type DnsMode = "open" | "trusted" | "synthetic";
 
+export type NetworkPolicyAction = "allow" | "deny";
+
+export type RuntimeNetworkPolicy = {
+  /** guest-initiated host egress policy */
+  egress?: NetworkPolicyAction;
+};
+
+export type EffectiveNetworkPolicy = Required<RuntimeNetworkPolicy>;
+
 export type SyntheticDnsHostMappingMode = "single" | "per-host";
 
 export type DnsOptions = {
@@ -171,5 +180,7 @@ export type QemuNetworkBackend<
   flush(): void;
   waitForFlowResume(key: string): Promise<void>;
   settleFlowResume(key: string, err?: Error): void;
+  getNetworkPolicy(): EffectiveNetworkPolicy;
+  isEgressAllowed(): boolean;
   abortTcpSession(key: string, session: TSession, reason: string): void;
 };

--- a/host/src/qemu/http.ts
+++ b/host/src/qemu/http.ts
@@ -133,6 +133,9 @@ export type HttpSession = {
 
   /** whether we already sent an interim 100-continue response */
   sentContinue?: boolean;
+
+  /** active upstream fetch abort controller */
+  activeFetchAbort?: AbortController;
 };
 
 function resetTaintState(
@@ -293,7 +296,7 @@ function maybeSend100ContinueFromHead(
   }
 }
 
-function cleanupStreamingBodyState(
+export function cleanupStreamingBodyState(
   backend: QemuNetworkBackend,
   httpSession: HttpSession,
   cause?: Error,
@@ -1336,6 +1339,8 @@ export async function fetchHookRequestAndRespond(
     const requestLabel = `${currentRequest.method} ${currentUrl.toString()}`;
     const responseStart = Date.now();
 
+    ensureRuntimeEgressAllowed(backend);
+
     const canSkipFirstHopPolicyChecks =
       isFirstHop &&
       policyCheckedFirstHop &&
@@ -1345,6 +1350,8 @@ export async function fetchHookRequestAndRespond(
       await ensureRequestAllowed(backend, currentRequest);
       await ensureIpAllowed(backend, currentUrl, protocol, port);
     }
+
+    ensureRuntimeEgressAllowed(backend);
 
     const useDefaultFetch = backend.options.fetch === undefined;
     const originKey = useDefaultFetch
@@ -1366,12 +1373,15 @@ export async function fetchHookRequestAndRespond(
         : undefined;
 
     let response: FetchResponse;
+    const abortController = new AbortController();
+    httpSession.activeFetchAbort = abortController;
     try {
       response = await fetcher(currentUrl.toString(), {
         method: currentRequest.method,
         headers: currentRequest.headers,
         body: bodyInit as any,
         redirect: "manual",
+        signal: abortController.signal,
         ...(bodyStream ? { duplex: "half" } : {}),
         ...(dispatcher ? { dispatcher } : {}),
       } as any);
@@ -1385,178 +1395,198 @@ export async function fetchHookRequestAndRespond(
           `http bridge fetch failed ${currentRequest.method} ${currentUrl.toString()} (${message})`,
         );
       }
+      clearActiveFetchAbort(httpSession, abortController);
       throw err;
     }
 
-    const redirectUrl = getRedirectUrl(response, currentUrl);
-    if (redirectUrl) {
-      if (response.body) {
-        await response.body.cancel();
-      }
+    try {
+      const redirectUrl = getRedirectUrl(response, currentUrl);
+      if (redirectUrl) {
+        if (response.body) {
+          await response.body.cancel();
+        }
 
-      if (redirectCount >= MAX_HTTP_REDIRECTS) {
-        throw new HttpRequestBlockedError(
-          "too many redirects",
-          508,
-          "Loop Detected",
-        );
-      }
+        if (redirectCount >= MAX_HTTP_REDIRECTS) {
+          throw new HttpRequestBlockedError(
+            "too many redirects",
+            508,
+            "Loop Detected",
+          );
+        }
 
-      if (bodyStream) {
-        // Streaming request bodies cannot be replayed on redirects.
-        const redirected = applyRedirectRequest(
-          {
-            method: currentRequest.method,
-            url: currentRequest.url,
-            headers: currentRequest.headers,
-            // Sentinel to indicate a non-empty body so redirect rewriting matches buffered semantics.
-            body: Buffer.alloc(1),
-          },
+        if (bodyStream) {
+          // Streaming request bodies cannot be replayed on redirects.
+          const redirected = applyRedirectRequest(
+            {
+              method: currentRequest.method,
+              url: currentRequest.url,
+              headers: currentRequest.headers,
+              // Sentinel to indicate a non-empty body so redirect rewriting matches buffered semantics.
+              body: Buffer.alloc(1),
+            },
+            response.status,
+            currentUrl,
+            redirectUrl,
+          );
+
+          if (redirected.body) {
+            throw new HttpRequestBlockedError(
+              "redirect requires replaying streamed request body",
+              502,
+              "Bad Gateway",
+            );
+          }
+
+          pendingRequest = {
+            method: redirected.method,
+            url: redirected.url,
+            headers: redirected.headers,
+            body: null,
+          };
+          continue;
+        }
+
+        pendingRequest = applyRedirectRequest(
+          currentRequest,
           response.status,
           currentUrl,
           redirectUrl,
         );
-
-        if (redirected.body) {
-          throw new HttpRequestBlockedError(
-            "redirect requires replaying streamed request body",
-            502,
-            "Bad Gateway",
-          );
-        }
-
-        pendingRequest = {
-          method: redirected.method,
-          url: redirected.url,
-          headers: redirected.headers,
-          body: null,
-        };
         continue;
       }
 
-      pendingRequest = applyRedirectRequest(
-        currentRequest,
-        response.status,
-        currentUrl,
-        redirectUrl,
-      );
-      continue;
-    }
-
-    if (backend.options.debug) {
-      backend.emitDebug(
-        `http bridge response ${response.status} ${response.statusText}`,
-      );
-    }
-
-    let responseHeaders = stripHopByHopHeaders(
-      responseHeadersToRecord(response.headers),
-    );
-    const contentEncodingValue = responseHeaders["content-encoding"];
-    const contentEncoding = Array.isArray(contentEncodingValue)
-      ? contentEncodingValue[0]
-      : contentEncodingValue;
-
-    const contentLengthValue = responseHeaders["content-length"];
-    const contentLength = Array.isArray(contentLengthValue)
-      ? contentLengthValue[0]
-      : contentLengthValue;
-
-    const parsedLength = contentLength ? Number(contentLength) : null;
-    const hasValidLength =
-      parsedLength !== null &&
-      Number.isFinite(parsedLength) &&
-      parsedLength >= 0;
-
-    if (contentEncoding) {
-      delete responseHeaders["content-encoding"];
-      delete responseHeaders["content-length"];
-    }
-    responseHeaders["connection"] = "close";
-
-    const responseBodyStream =
-      response.body as WebReadableStream<Uint8Array> | null;
-
-    const suppressBody =
-      currentRequest.method === "HEAD" ||
-      response.status === 204 ||
-      response.status === 205 ||
-      response.status === 304;
-
-    if (suppressBody) {
-      if (responseBodyStream) {
-        try {
-          await responseBodyStream.cancel();
-        } catch {
-          // ignore cancellation failures
-        }
+      if (backend.options.debug) {
+        backend.emitDebug(
+          `http bridge response ${response.status} ${response.statusText}`,
+        );
       }
 
-      // No message body is allowed for these responses.
-      delete responseHeaders["transfer-encoding"];
+      let responseHeaders = stripHopByHopHeaders(
+        responseHeadersToRecord(response.headers),
+      );
+      const contentEncodingValue = responseHeaders["content-encoding"];
+      const contentEncoding = Array.isArray(contentEncodingValue)
+        ? contentEncodingValue[0]
+        : contentEncodingValue;
 
-      if (
+      const contentLengthValue = responseHeaders["content-length"];
+      const contentLength = Array.isArray(contentLengthValue)
+        ? contentLengthValue[0]
+        : contentLengthValue;
+
+      const parsedLength = contentLength ? Number(contentLength) : null;
+      const hasValidLength =
+        parsedLength !== null &&
+        Number.isFinite(parsedLength) &&
+        parsedLength >= 0;
+
+      if (contentEncoding) {
+        delete responseHeaders["content-encoding"];
+        delete responseHeaders["content-length"];
+      }
+      responseHeaders["connection"] = "close";
+
+      const responseBodyStream =
+        response.body as WebReadableStream<Uint8Array> | null;
+
+      const suppressBody =
+        currentRequest.method === "HEAD" ||
         response.status === 204 ||
         response.status === 205 ||
-        response.status === 304
-      ) {
-        delete responseHeaders["content-encoding"];
-        responseHeaders["content-length"] = "0";
-      } else {
-        // HEAD: preserve Content-Length if present, otherwise be explicit.
-        if (!responseHeaders["content-length"])
+        response.status === 304;
+
+      if (suppressBody) {
+        if (responseBodyStream) {
+          try {
+            await responseBodyStream.cancel();
+          } catch {
+            // ignore cancellation failures
+          }
+        }
+
+        // No message body is allowed for these responses.
+        delete responseHeaders["transfer-encoding"];
+
+        if (
+          response.status === 204 ||
+          response.status === 205 ||
+          response.status === 304
+        ) {
+          delete responseHeaders["content-encoding"];
           responseHeaders["content-length"] = "0";
+        } else {
+          // HEAD: preserve Content-Length if present, otherwise be explicit.
+          if (!responseHeaders["content-length"])
+            responseHeaders["content-length"] = "0";
+        }
+
+        let hookResponse: InternalHttpResponse = {
+          status: response.status,
+          statusText: response.statusText || "OK",
+          headers: responseHeaders,
+          body: Buffer.alloc(0),
+        };
+
+        hookResponse = await applyResponseHooks(
+          backend,
+          hookResponse,
+          currentRequest,
+        );
+
+        sendHttpResponse(
+          write,
+          normalizeHookResponseForGuest(hookResponse, currentRequest.method),
+          httpVersion,
+        );
+        return;
       }
 
-      let hookResponse: InternalHttpResponse = {
-        status: response.status,
-        statusText: response.statusText || "OK",
-        headers: responseHeaders,
-        body: Buffer.alloc(0),
-      };
+      const canStream =
+        Boolean(responseBodyStream) && !backend.options.httpHooks?.onResponse;
 
-      hookResponse = await applyResponseHooks(
-        backend,
-        hookResponse,
-        currentRequest,
-      );
+      if (canStream && responseBodyStream) {
+        const allowChunked = httpVersion === "HTTP/1.1";
+        let streamedBytes = 0;
 
-      sendHttpResponse(
-        write,
-        normalizeHookResponseForGuest(hookResponse, currentRequest.method),
-        httpVersion,
-      );
-      return;
-    }
+        try {
+          if (contentEncoding || !hasValidLength) {
+            delete responseHeaders["content-length"];
 
-    const canStream =
-      Boolean(responseBodyStream) && !backend.options.httpHooks?.onResponse;
-
-    if (canStream && responseBodyStream) {
-      const allowChunked = httpVersion === "HTTP/1.1";
-      let streamedBytes = 0;
-
-      try {
-        if (contentEncoding || !hasValidLength) {
-          delete responseHeaders["content-length"];
-
-          if (allowChunked) {
-            responseHeaders["transfer-encoding"] = "chunked";
-            sendHttpResponseHead(
-              write,
-              {
-                status: response.status,
-                statusText: response.statusText || "OK",
-                headers: responseHeaders,
-              },
-              httpVersion,
-            );
-            streamedBytes = await sendChunkedBody(
-              responseBodyStream,
-              write,
-              waitForWritable,
-            );
+            if (allowChunked) {
+              responseHeaders["transfer-encoding"] = "chunked";
+              sendHttpResponseHead(
+                write,
+                {
+                  status: response.status,
+                  statusText: response.statusText || "OK",
+                  headers: responseHeaders,
+                },
+                httpVersion,
+              );
+              streamedBytes = await sendChunkedBody(
+                responseBodyStream,
+                write,
+                waitForWritable,
+              );
+            } else {
+              delete responseHeaders["transfer-encoding"];
+              sendHttpResponseHead(
+                write,
+                {
+                  status: response.status,
+                  statusText: response.statusText || "OK",
+                  headers: responseHeaders,
+                },
+                httpVersion,
+              );
+              streamedBytes = await sendStreamBody(
+                responseBodyStream,
+                write,
+                waitForWritable,
+              );
+            }
           } else {
+            responseHeaders["content-length"] = parsedLength!.toString();
             delete responseHeaders["transfer-encoding"];
             sendHttpResponseHead(
               write,
@@ -1573,106 +1603,91 @@ export async function fetchHookRequestAndRespond(
               waitForWritable,
             );
           }
-        } else {
-          responseHeaders["content-length"] = parsedLength!.toString();
-          delete responseHeaders["transfer-encoding"];
-          sendHttpResponseHead(
-            write,
-            {
-              status: response.status,
-              statusText: response.statusText || "OK",
-              headers: responseHeaders,
-            },
-            httpVersion,
+        } catch (err) {
+          if (originKey) {
+            evictSharedDispatcher(backend, originKey);
+          }
+          try {
+            await responseBodyStream.cancel();
+          } catch {
+            // ignore cancellation failures
+          }
+          throw err;
+        }
+
+        if (backend.options.debug) {
+          const elapsed = Date.now() - responseStart;
+          backend.emitDebug(
+            `http bridge body complete ${requestLabel} ${streamedBytes} bytes in ${elapsed}ms`,
           );
-          streamedBytes = await sendStreamBody(
-            responseBodyStream,
-            write,
-            waitForWritable,
-          );
         }
-      } catch (err) {
-        if (originKey) {
-          evictSharedDispatcher(backend, originKey);
-        }
-        try {
-          await responseBodyStream.cancel();
-        } catch {
-          // ignore cancellation failures
-        }
-        throw err;
+
+        return;
       }
 
-      if (backend.options.debug) {
-        const elapsed = Date.now() - responseStart;
-        backend.emitDebug(
-          `http bridge body complete ${requestLabel} ${streamedBytes} bytes in ${elapsed}ms`,
+      const maxResponseBytes = backend.http.maxHttpResponseBodyBytes;
+
+      if (
+        hasValidLength &&
+        !contentEncoding &&
+        parsedLength! > maxResponseBytes
+      ) {
+        if (responseBodyStream) {
+          try {
+            await responseBodyStream.cancel();
+          } catch {
+            // ignore cancellation failures
+          }
+        }
+        throw new HttpRequestBlockedError(
+          `response body exceeds ${maxResponseBytes} bytes`,
+          502,
+          "Bad Gateway",
         );
       }
 
-      return;
-    }
+      const responseBody = responseBodyStream
+        ? await bufferResponseBodyWithLimit(responseBodyStream, maxResponseBytes)
+        : Buffer.from(await response.arrayBuffer());
 
-    const maxResponseBytes = backend.http.maxHttpResponseBodyBytes;
-
-    if (
-      hasValidLength &&
-      !contentEncoding &&
-      parsedLength! > maxResponseBytes
-    ) {
-      if (responseBodyStream) {
-        try {
-          await responseBodyStream.cancel();
-        } catch {
-          // ignore cancellation failures
-        }
+      if (responseBody.length > maxResponseBytes) {
+        throw new HttpRequestBlockedError(
+          `response body exceeds ${maxResponseBytes} bytes`,
+          502,
+          "Bad Gateway",
+        );
       }
-      throw new HttpRequestBlockedError(
-        `response body exceeds ${maxResponseBytes} bytes`,
-        502,
-        "Bad Gateway",
+
+      responseHeaders["content-length"] = responseBody.length.toString();
+
+      let hookResponse: InternalHttpResponse = {
+        status: response.status,
+        statusText: response.statusText || "OK",
+        headers: responseHeaders,
+        body: responseBody,
+      };
+
+      hookResponse = await applyResponseHooks(
+        backend,
+        hookResponse,
+        currentRequest,
       );
-    }
-
-    const responseBody = responseBodyStream
-      ? await bufferResponseBodyWithLimit(responseBodyStream, maxResponseBytes)
-      : Buffer.from(await response.arrayBuffer());
-
-    if (responseBody.length > maxResponseBytes) {
-      throw new HttpRequestBlockedError(
-        `response body exceeds ${maxResponseBytes} bytes`,
-        502,
-        "Bad Gateway",
+      hookResponse = normalizeHookResponseForGuest(
+        hookResponse,
+        currentRequest.method,
       );
+
+      sendHttpResponse(write, hookResponse, httpVersion);
+      if (backend.options.debug) {
+        const elapsed = Date.now() - responseStart;
+        backend.emitDebug(
+          `http bridge body complete ${requestLabel} ${hookResponse.body.length} bytes in ${elapsed}ms`,
+        );
+      }
+      return;
+    } finally {
+      clearActiveFetchAbort(httpSession, abortController);
     }
-
-    responseHeaders["content-length"] = responseBody.length.toString();
-
-    let hookResponse: InternalHttpResponse = {
-      status: response.status,
-      statusText: response.statusText || "OK",
-      headers: responseHeaders,
-      body: responseBody,
-    };
-
-    hookResponse = await applyResponseHooks(
-      backend,
-      hookResponse,
-      currentRequest,
-    );
-    hookResponse = normalizeHookResponseForGuest(
-      hookResponse,
-      currentRequest.method,
-    );
-
-    sendHttpResponse(write, hookResponse, httpVersion);
-    if (backend.options.debug) {
-      const elapsed = Date.now() - responseStart;
-      backend.emitDebug(
-        `http bridge body complete ${requestLabel} ${hookResponse.body.length} bytes in ${elapsed}ms`,
-      );
-    }
-    return;
   }
 }
 
@@ -1788,6 +1803,8 @@ async function handleWebSocketUpgrade(
   if (!Number.isFinite(port) || port <= 0) {
     throw new HttpRequestBlockedError("invalid port", 400, "Bad Request");
   }
+
+  ensureRuntimeEgressAllowed(backend);
 
   // Resolve all A/AAAA records and pick the first IP allowed by policy.
   // This pins the websocket tunnel to an allowed address and avoids rejecting
@@ -2032,6 +2049,20 @@ function shouldPrecheckRequestPolicies(backend: QemuNetworkBackend): boolean {
   }
 
   return onRequest[ON_REQUEST_EARLY_POLICY_SAFE] === true;
+}
+
+function ensureRuntimeEgressAllowed(backend: QemuNetworkBackend) {
+  if (backend.isEgressAllowed()) return;
+  throw new HttpRequestBlockedError("blocked by runtime egress policy");
+}
+
+function clearActiveFetchAbort(
+  httpSession: HttpSession,
+  abortController: AbortController,
+) {
+  if (httpSession.activeFetchAbort === abortController) {
+    httpSession.activeFetchAbort = undefined;
+  }
 }
 
 async function ensureRequestHeadPolicies(

--- a/host/src/qemu/net.ts
+++ b/host/src/qemu/net.ts
@@ -54,6 +54,7 @@ import {
 } from "../http/utils.ts";
 
 import {
+  cleanupStreamingBodyState,
   handlePlainHttpData,
   handleTlsHttpData,
   updateQemuRxPauseState,
@@ -64,8 +65,11 @@ import {
   createGuestClosedError,
   type DnsMode,
   type DnsOptions,
+  type EffectiveNetworkPolicy,
   type HttpFetch,
   type HttpHooks,
+  type NetworkPolicyAction,
+  type RuntimeNetworkPolicy,
   type SyntheticDnsHostMappingMode,
 } from "./contracts.ts";
 import { QemuIcmpTracker, type IcmpTiming } from "./icmp.ts";
@@ -185,6 +189,10 @@ export type TcpSession = {
   ws?: WebSocketState;
 };
 
+const DEFAULT_NETWORK_POLICY: EffectiveNetworkPolicy = {
+  egress: "allow",
+};
+
 /** @internal */
 export type QemuHttpInternals = {
   /** max intercepted http request body size in `bytes` */
@@ -208,9 +216,12 @@ export type QemuHttpInternals = {
 export type {
   DnsMode,
   DnsOptions,
+  EffectiveNetworkPolicy,
   HttpFetch,
   HttpHooks,
   HttpIpAllowInfo,
+  NetworkPolicyAction,
+  RuntimeNetworkPolicy,
   SyntheticDnsHostMappingMode,
 } from "./contracts.ts";
 export type { TcpOptions } from "./tcp.ts";
@@ -359,6 +370,7 @@ export class QemuNetworkBackend extends EventEmitter {
   };
   private readonly syntheticDnsHostMapping: SyntheticDnsHostMappingMode;
   private readonly syntheticDnsHostMap: SyntheticDnsHostMap | null;
+  private networkPolicy: EffectiveNetworkPolicy = { ...DEFAULT_NETWORK_POLICY };
 
   constructor(options: QemuNetworkOptions) {
     super();
@@ -458,6 +470,39 @@ export class QemuNetworkBackend extends EventEmitter {
     this.server.listen(this.options.socketPath);
   }
 
+  getNetworkPolicy(): EffectiveNetworkPolicy {
+    return { ...this.networkPolicy };
+  }
+
+  setNetworkPolicy(policy: RuntimeNetworkPolicy): EffectiveNetworkPolicy {
+    for (const key of Object.keys(policy)) {
+      if (key !== "egress") {
+        throw new Error(`unknown network policy field: ${key}`);
+      }
+    }
+    if (policy.egress !== undefined && !isNetworkPolicyAction(policy.egress)) {
+      throw new Error("network policy egress must be 'allow' or 'deny'");
+    }
+
+    const next: EffectiveNetworkPolicy = {
+      egress: policy.egress ?? this.networkPolicy.egress,
+    };
+
+    this.networkPolicy = next;
+
+    if (this.options.debug) {
+      this.emitDebug(`network policy egress=${next.egress}`);
+    }
+
+    this.closeSessionsDeniedByPolicy();
+
+    return this.getNetworkPolicy();
+  }
+
+  isEgressAllowed(): boolean {
+    return this.networkPolicy.egress === "allow";
+  }
+
   async close(): Promise<void> {
     this.detachSocket();
     closeSharedDispatchers(this);
@@ -551,11 +596,11 @@ export class QemuNetworkBackend extends EventEmitter {
       allowTcpFlow: (info) => {
         if (info.protocol === "tcp") {
           const session = this.tcpSessions.get(info.key);
-          const allowed = Boolean(session?.mappedTcp);
+          const allowed = Boolean(session?.mappedTcp) && this.isEgressAllowed();
           if (!allowed) {
             if (this.options.debug) {
               this.emitDebug(
-                `tcp blocked ${info.srcIP}:${info.srcPort} -> ${info.dstIP}:${info.dstPort} (${info.protocol})`,
+                `tcp blocked ${info.srcIP}:${info.srcPort} -> ${info.dstIP}:${info.dstPort} (${info.protocol}${this.isEgressAllowed() ? "" : ", runtime egress policy"})`,
               );
             }
             return false;
@@ -568,16 +613,13 @@ export class QemuNetworkBackend extends EventEmitter {
         }
 
         if (info.protocol === "ssh") {
-          const allowed = isSshFlowAllowed(
-            this,
-            info.key,
-            info.dstIP,
-            info.dstPort,
-          );
+          const allowed =
+            this.isEgressAllowed() &&
+            isSshFlowAllowed(this, info.key, info.dstIP, info.dstPort);
           if (!allowed) {
             if (this.options.debug) {
               this.emitDebug(
-                `tcp blocked ${info.srcIP}:${info.srcPort} -> ${info.dstIP}:${info.dstPort} (${info.protocol})`,
+                `tcp blocked ${info.srcIP}:${info.srcPort} -> ${info.dstIP}:${info.dstPort} (${info.protocol}${this.isEgressAllowed() ? "" : ", runtime egress policy"})`,
               );
             }
             return false;
@@ -594,6 +636,15 @@ export class QemuNetworkBackend extends EventEmitter {
           if (this.options.debug) {
             this.emitDebug(
               `tcp blocked ${info.srcIP}:${info.srcPort} -> ${info.dstIP}:${info.dstPort} (${info.protocol})`,
+            );
+          }
+          return false;
+        }
+
+        if (!this.isEgressAllowed()) {
+          if (this.options.debug) {
+            this.emitDebug(
+              `tcp blocked ${info.srcIP}:${info.srcPort} -> ${info.dstIP}:${info.dstPort} (${info.protocol}, runtime egress policy)`,
             );
           }
           return false;
@@ -679,13 +730,42 @@ export class QemuNetworkBackend extends EventEmitter {
 
     for (const session of this.tcpSessions.values()) {
       try {
+        session.http?.activeFetchAbort?.abort();
+      } catch {
+        // ignore
+      }
+      try {
         session.socket?.destroy();
+      } catch {
+        // ignore
+      }
+      try {
+        session.tls?.socket.destroy();
       } catch {
         // ignore
       }
       cleanupSshTcpSession(this, session);
     }
     this.tcpSessions.clear();
+  }
+
+  private closeSessionsDeniedByPolicy() {
+    if (this.isEgressAllowed()) return;
+
+    closeSharedDispatchers(this);
+
+    for (const session of this.udpSessions.values()) {
+      try {
+        session.socket.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.udpSessions.clear();
+
+    for (const [key, session] of [...this.tcpSessions.entries()]) {
+      this.abortTcpSession(key, session, "runtime-network-policy");
+    }
   }
 
   private pickTrustedDnsServer(): string {
@@ -742,6 +822,15 @@ export class QemuNetworkBackend extends EventEmitter {
   }
 
   private handleUdpSend(message: UdpSendMessage) {
+    if (!this.isEgressAllowed()) {
+      if (this.options.debug) {
+        this.emitDebug(
+          `udp blocked ${message.srcIP}:${message.srcPort} -> ${message.dstIP}:${message.dstPort} (runtime egress policy)`,
+        );
+      }
+      return;
+    }
+
     if (message.dstPort !== 53) {
       if (this.options.debug) {
         this.emitDebug(
@@ -901,8 +990,21 @@ export class QemuNetworkBackend extends EventEmitter {
       );
     }
 
+    if (session.http) {
+      cleanupStreamingBodyState(this, session.http, GUEST_CLOSED_ERR);
+    }
+    try {
+      session.http?.activeFetchAbort?.abort();
+    } catch {
+      // ignore
+    }
     try {
       session.socket?.destroy();
+    } catch {
+      // ignore
+    }
+    try {
+      session.tls?.socket.destroy();
     } catch {
       // ignore
     }
@@ -1368,6 +1470,10 @@ export class QemuNetworkBackend extends EventEmitter {
       return { keyPem, certPem };
     }
   }
+}
+
+function isNetworkPolicyAction(value: unknown): value is NetworkPolicyAction {
+  return value === "allow" || value === "deny";
 }
 
 function formatError(err: unknown): string {

--- a/host/src/qemu/ws.ts
+++ b/host/src/qemu/ws.ts
@@ -122,12 +122,33 @@ export async function bridgeWebSocketUpgrade(
     throw new Error("internal error: websocket state missing");
   }
 
-  const upstream = await connectWebSocketUpstream(backend, {
-    protocol: info.protocol,
-    hostname: info.parsedUrl.hostname,
-    address: info.address,
-    port: info.port,
-  });
+  if (!backend.isEgressAllowed()) {
+    abortWebSocketSession(backend, key, session, "runtime-egress-policy");
+    return false;
+  }
+
+  const upstream = await connectWebSocketUpstream(
+    backend,
+    {
+      protocol: info.protocol,
+      hostname: info.parsedUrl.hostname,
+      address: info.address,
+      port: info.port,
+    },
+    (socket) => {
+      session.socket = socket;
+    },
+  );
+
+  if (!backend.isEgressAllowed()) {
+    try {
+      upstream.destroy();
+    } catch {
+      // ignore
+    }
+    abortWebSocketSession(backend, key, session, "runtime-egress-policy");
+    return false;
+  }
 
   ws.upstream = upstream;
 
@@ -266,6 +287,7 @@ export async function connectWebSocketUpstream(
     address: string;
     port: number;
   },
+  onSocket?: (socket: net.Socket) => void,
 ): Promise<net.Socket> {
   const timeoutMs = backend.http.webSocketUpstreamConnectTimeoutMs;
 
@@ -276,6 +298,7 @@ export async function connectWebSocketUpstream(
       servername: info.hostname,
       ALPNProtocols: ["http/1.1"],
     });
+    onSocket?.(socket);
 
     await new Promise<void>((resolve, reject) => {
       let settled = false;
@@ -288,6 +311,7 @@ export async function connectWebSocketUpstream(
         }
         socket.off("error", onError);
         socket.off("secureConnect", onConnect);
+        socket.off("close", onClose);
       };
 
       const settleResolve = () => {
@@ -312,6 +336,10 @@ export async function connectWebSocketUpstream(
         settleResolve();
       };
 
+      const onClose = () => {
+        settleReject(new Error("websocket upstream closed before connect"));
+      };
+
       if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
         timer = setTimeout(() => {
           const err = new Error(
@@ -328,12 +356,14 @@ export async function connectWebSocketUpstream(
 
       socket.once("error", onError);
       socket.once("secureConnect", onConnect);
+      socket.once("close", onClose);
     });
 
     return socket;
   }
 
   const socket = new net.Socket();
+  onSocket?.(socket);
   socket.connect(info.port, info.address);
 
   await new Promise<void>((resolve, reject) => {
@@ -347,6 +377,7 @@ export async function connectWebSocketUpstream(
       }
       socket.off("error", onError);
       socket.off("connect", onConnect);
+      socket.off("close", onClose);
     };
 
     const settleResolve = () => {
@@ -371,6 +402,10 @@ export async function connectWebSocketUpstream(
       settleResolve();
     };
 
+    const onClose = () => {
+      settleReject(new Error("websocket upstream closed before connect"));
+    };
+
     if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
       timer = setTimeout(() => {
         const err = new Error(
@@ -387,6 +422,7 @@ export async function connectWebSocketUpstream(
 
     socket.once("error", onError);
     socket.once("connect", onConnect);
+    socket.once("close", onClose);
   });
 
   return socket;

--- a/host/src/sandbox/control-protocol.ts
+++ b/host/src/sandbox/control-protocol.ts
@@ -1,3 +1,8 @@
+import type {
+  EffectiveNetworkPolicy,
+  RuntimeNetworkPolicy,
+} from "../qemu/net.ts";
+
 /**
  * Sandbox control protocol.
  *
@@ -11,12 +16,14 @@
  * - pty_resize { type: "pty_resize", id, rows, cols }
  * - lifecycle { type: "lifecycle", action: "restart" | "shutdown" }
  * - snapshot { type: "snapshot", id, path }
+ * - network_policy { type: "network_policy", id, policy }
  * - boot { type: "boot", fuseMount?, fuseBinds? }
  *
  * Server → Client:
  * - status { type: "status", state: "starting" | "running" | "stopped" }
  * - exec_response { type: "exec_response", id, exit_code, signal? }
  * - snapshot_response { type: "snapshot_response", id, path, name }
+ * - network_policy_response { type: "network_policy_response", id, policy }
  * - error { type: "error", id?, code, message }
  *
  * Binary output frame:
@@ -82,6 +89,14 @@ export type SnapshotCommandMessage = {
   path: string;
 };
 
+export type NetworkPolicyCommandMessage = {
+  type: "network_policy";
+  /** request id */
+  id: number;
+  /** partial runtime policy update */
+  policy?: RuntimeNetworkPolicy;
+};
+
 export type BootCommandMessage = {
   type: "boot";
   /** guest mountpoint for fuse (defaults to server config) */
@@ -107,7 +122,8 @@ export type ClientMessage =
   | PtyResizeCommandMessage
   | ExecWindowCommandMessage
   | LifecycleCommandMessage
-  | SnapshotCommandMessage;
+  | SnapshotCommandMessage
+  | NetworkPolicyCommandMessage;
 
 export type ExecResponseMessage = {
   type: "exec_response";
@@ -139,6 +155,14 @@ export type SnapshotResponseMessage = {
   name: string;
 };
 
+export type NetworkPolicyResponseMessage = {
+  type: "network_policy_response";
+  /** request id */
+  id: number;
+  /** effective runtime network policy */
+  policy: EffectiveNetworkPolicy;
+};
+
 export type StatusMessage = {
   type: "status";
   /** sandbox state */
@@ -149,6 +173,7 @@ export type ServerMessage =
   | ExecResponseMessage
   | ErrorMessage
   | SnapshotResponseMessage
+  | NetworkPolicyResponseMessage
   | StatusMessage;
 
 export type OutputStream = "stdout" | "stderr";

--- a/host/src/sandbox/server.ts
+++ b/host/src/sandbox/server.ts
@@ -30,7 +30,11 @@ import {
   type SandboxLogStream,
 } from "./controller.ts";
 import { KrunController, type KrunConfig } from "./krun-controller.ts";
-import { QemuNetworkBackend } from "../qemu/net.ts";
+import {
+  QemuNetworkBackend,
+  type EffectiveNetworkPolicy,
+  type RuntimeNetworkPolicy,
+} from "../qemu/net.ts";
 import { FsRpcService } from "../vfs/rpc-service.ts";
 import { LINUX_ERRNO } from "../vfs/linux-errno.ts";
 import { SandboxVfsProvider } from "../vfs/provider.ts";
@@ -304,6 +308,19 @@ export class SandboxServer extends EventEmitter {
   /** @internal resolved qemu binary path */
   getQemuPath(): string {
     return this.options.qemuPath;
+  }
+
+  /** current runtime network egress policy */
+  getNetworkPolicy(): EffectiveNetworkPolicy {
+    return this.network?.getNetworkPolicy() ?? { egress: "deny" };
+  }
+
+  /** update runtime network egress policy */
+  setNetworkPolicy(policy: RuntimeNetworkPolicy): EffectiveNetworkPolicy {
+    if (!this.network) {
+      throw new Error("networking is disabled for this VM");
+    }
+    return this.network.setNetworkPolicy(policy);
   }
 
   /**

--- a/host/src/session-registry.ts
+++ b/host/src/session-registry.ts
@@ -12,6 +12,8 @@ import {
   type ExecCommandMessage,
   type ExecResponseMessage,
   type ExecWindowCommandMessage,
+  type NetworkPolicyCommandMessage,
+  type NetworkPolicyResponseMessage,
   type PtyResizeCommandMessage,
   type ServerMessage,
   type SnapshotCommandMessage,
@@ -312,6 +314,10 @@ type SessionIpcServerHandlers = {
   onSnapshot?: (
     message: SnapshotCommandMessage,
   ) => Promise<SessionSnapshotResult>;
+  /** update or read runtime network policy for a running session */
+  onNetworkPolicy?: (
+    message: NetworkPolicyCommandMessage,
+  ) => Promise<NetworkPolicyResponseMessage["policy"]>;
 };
 
 export class SessionIpcServer {
@@ -584,9 +590,16 @@ export class SessionIpcServer {
       }
     };
 
+    const assertRequestId = (id: number, label: string): boolean => {
+      if (!Number.isInteger(id) || id < 0) {
+        sendError(socket, "invalid_request", `${label} requires a uint32 id`);
+        return false;
+      }
+      return true;
+    };
+
     const handleSnapshot = (message: SnapshotCommandMessage): void => {
-      if (!Number.isInteger(message.id) || message.id < 0) {
-        sendError(socket, "invalid_request", "snapshot requires a uint32 id");
+      if (!assertRequestId(message.id, "snapshot")) {
         return;
       }
 
@@ -641,6 +654,39 @@ export class SessionIpcServer {
         });
     };
 
+    const handleNetworkPolicy = (
+      message: NetworkPolicyCommandMessage,
+    ): void => {
+      if (!assertRequestId(message.id, "network_policy")) {
+        return;
+      }
+
+      if (!this.handlers.onNetworkPolicy) {
+        sendError(
+          socket,
+          "unsupported",
+          "network policy actions are not supported for this session",
+          message.id,
+        );
+        return;
+      }
+
+      void this.handlers
+        .onNetworkPolicy(message)
+        .then((policy) => {
+          const response: NetworkPolicyResponseMessage = {
+            type: "network_policy_response",
+            id: message.id,
+            policy,
+          };
+          sendJson(socket, response);
+        })
+        .catch((err) => {
+          const detail = err instanceof Error ? err.message : String(err);
+          sendError(socket, "network_policy_failed", detail, message.id);
+        });
+    };
+
     const handleMessage = (message: ClientMessage): void => {
       if (message.type === "boot") {
         // Attach clients connect to an already-running VM; ignore boot requests.
@@ -669,6 +715,11 @@ export class SessionIpcServer {
 
       if (message.type === "snapshot") {
         handleSnapshot(message);
+        return;
+      }
+
+      if (message.type === "network_policy") {
+        handleNetworkPolicy(message);
         return;
       }
 

--- a/host/src/vm/core.ts
+++ b/host/src/vm/core.ts
@@ -66,6 +66,10 @@ import {
   type DebugComponent,
   type DebugLogFn,
 } from "../debug.ts";
+import type {
+  EffectiveNetworkPolicy,
+  RuntimeNetworkPolicy,
+} from "../qemu/net.ts";
 import {
   IngressGateway,
   type EnableIngressOptions,
@@ -164,6 +168,10 @@ export type {
   VmFsDeleteOptions,
 } from "./fs.ts";
 export type { VMOptions, VmRootfsOptions, VmVfsOptions } from "./types.ts";
+export type {
+  EffectiveNetworkPolicy,
+  RuntimeNetworkPolicy,
+} from "../qemu/net.ts";
 
 export type ShellOptions = {
   /** command to run (default: /bin/bash) */
@@ -593,6 +601,33 @@ export class VM {
    */
   async close() {
     return this.closeSingleflight.run(() => this.closeInternal());
+  }
+
+  /**
+   * Return the current host-enforced runtime network egress policy.
+   */
+  getNetworkPolicy(): EffectiveNetworkPolicy {
+    const server = this.server;
+    if (!server) throw new Error("VM is closed");
+    return server.getNetworkPolicy();
+  }
+
+  /**
+   * Update the host-enforced runtime network egress policy.
+   *
+   * `egress: "deny"` blocks VM-mediated guest-initiated host egress, including
+   * DNS, HTTP/HTTPS/WebSocket traffic, SSH, and mapped TCP. Existing egress
+   * sessions are always closed when the policy changes to deny.
+   */
+  setNetworkPolicy(policy: RuntimeNetworkPolicy): EffectiveNetworkPolicy {
+    const server = this.server;
+    if (!server) throw new Error("VM is closed");
+    return server.setNetworkPolicy(policy);
+  }
+
+  /** Enable or disable the runtime gate for VM-mediated guest-initiated egress. */
+  setOutboundEgressEnabled(enabled: boolean): EffectiveNetworkPolicy {
+    return this.setNetworkPolicy({ egress: enabled ? "allow" : "deny" });
   }
 
   /**
@@ -1314,6 +1349,13 @@ fi
                 await this.close();
               },
             };
+          },
+          onNetworkPolicy: async (message) => {
+            const policy = message.policy ?? {};
+            if (message.policy) {
+              return this.setNetworkPolicy(policy);
+            }
+            return this.getNetworkPolicy();
           },
         },
       );

--- a/host/test/qemu-net.test.ts
+++ b/host/test/qemu-net.test.ts
@@ -234,6 +234,193 @@ test("qemu-net: synthetic per-host dns mapping does not throw on mapping exhaust
   assert.deepEqual([...response.subarray(response.length - 4)], [192, 0, 2, 1]);
 });
 
+test("qemu-net: runtime network policy defaults and validates updates", () => {
+  const backend = makeBackend();
+
+  assert.deepEqual(backend.getNetworkPolicy(), {
+    egress: "allow",
+  });
+
+  assert.deepEqual(backend.setNetworkPolicy({ egress: "deny" }), {
+    egress: "deny",
+  });
+  assert.equal(backend.isEgressAllowed(), false);
+
+  assert.throws(
+    () => backend.setNetworkPolicy({ egress: "bogus" as any }),
+    /egress must be 'allow' or 'deny'/,
+  );
+  assert.throws(
+    () => backend.setNetworkPolicy({ unknown: "deny" } as any),
+    /unknown network policy field/,
+  );
+});
+
+test("qemu-net: runtime egress deny blocks upstream HTTP bridge", async () => {
+  const backend = makeBackend({
+    fetch: async () => {
+      throw new Error("fetch should not be called");
+    },
+  });
+  backend.setNetworkPolicy({ egress: "deny" });
+
+  await assert.rejects(
+    fetchHookAndRespond(
+      backend,
+      {
+        method: "GET",
+        target: "/",
+        version: "HTTP/1.1",
+        headers: { host: "example.com" },
+        body: Buffer.alloc(0),
+      },
+      "http",
+      () => {},
+    ),
+    /blocked by runtime egress policy/,
+  );
+});
+
+test("qemu-net: active HTTP response fetch remains abortable", async () => {
+  let bodyController: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let fetchCalled = false;
+  const backend = makeBackend({
+    fetch: async (_url, init: any) => {
+      fetchCalled = true;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          bodyController = controller;
+          init.signal.addEventListener("abort", () => {
+            controller.error(new Error("fetch aborted"));
+          });
+        },
+      });
+      return new UndiciResponse(body as any, { status: 200 }) as any;
+    },
+  });
+  const httpSession: qemuHttp.HttpSession = {
+    buffer: new HttpReceiveBuffer(),
+    processing: false,
+    closed: false,
+    upstreamTainted: false,
+    upstreamOriginKey: null,
+    sentContinue: false,
+  };
+
+  const request = qemuHttp.fetchHookRequestAndRespond(backend, {
+    request: {
+      method: "GET",
+      url: "http://example.com/stream",
+      headers: { host: "example.com" },
+      body: null,
+    },
+    httpVersion: "HTTP/1.1",
+    write: () => {},
+    httpSession,
+  });
+
+  while (!fetchCalled || !bodyController) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  assert.ok(httpSession.activeFetchAbort);
+  httpSession.activeFetchAbort.abort();
+  await assert.rejects(request, /fetch aborted/);
+  assert.equal(httpSession.activeFetchAbort, undefined);
+});
+
+test("qemu-net: runtime egress deny closes existing sessions by default", () => {
+  const backend = makeBackend();
+  let destroyed = false;
+  let aborted = false;
+
+  (backend as any).tcpSessions.set("flow", {
+    socket: { destroy: () => void (destroyed = true) },
+    srcIP: "192.168.127.3",
+    srcPort: 1234,
+    dstIP: "198.51.100.1",
+    dstPort: 443,
+    connectIP: "198.51.100.1",
+    connectPort: 443,
+    syntheticHostname: null,
+    mappedTcp: null,
+    flowControlPaused: false,
+    protocol: "tls",
+    connected: true,
+    pendingWrites: [],
+    pendingWriteBytes: 0,
+    http: { activeFetchAbort: { abort: () => void (aborted = true) } },
+  });
+
+  backend.setNetworkPolicy({ egress: "deny" });
+
+  assert.equal(destroyed, true);
+  assert.equal(aborted, true);
+  assert.equal((backend as any).tcpSessions.has("flow"), false);
+});
+
+test("qemu-net: runtime egress deny closes shared HTTP dispatchers", () => {
+  const backend = makeBackend();
+  let closed = false;
+
+  backend.http.sharedDispatchers.set("http://example.com:80", {
+    dispatcher: { close: () => void (closed = true) } as any,
+    lastUsedAt: Date.now(),
+  });
+
+  backend.setNetworkPolicy({ egress: "deny" });
+
+  assert.equal(closed, true);
+  assert.equal(backend.http.sharedDispatchers.size, 0);
+});
+
+test("qemu-net: runtime egress deny clears paused streaming upload state", () => {
+  const backend = makeBackend();
+  let resumed = false;
+  backend.socket = { resume: () => void (resumed = true) } as any;
+  backend.http.qemuRxPausedForHttpStreaming = true;
+
+  (backend as any).tcpSessions.set("flow", {
+    socket: null,
+    srcIP: "192.168.127.3",
+    srcPort: 1234,
+    dstIP: "198.51.100.1",
+    dstPort: 443,
+    connectIP: "198.51.100.1",
+    connectPort: 443,
+    syntheticHostname: null,
+    mappedTcp: null,
+    flowControlPaused: false,
+    protocol: "http",
+    connected: true,
+    pendingWrites: [],
+    pendingWriteBytes: 0,
+    http: {
+      buffer: new HttpReceiveBuffer(),
+      processing: true,
+      closed: false,
+      upstreamTainted: false,
+      upstreamOriginKey: null,
+      streamingBody: {
+        remaining: 1024,
+        controller: null,
+        done: false,
+        dropRemainingBody: false,
+        pipelineBytes: 0,
+        pending: [Buffer.alloc(512 * 1024)],
+        pendingBytes: 512 * 1024,
+        closeAfterPending: false,
+        drain: () => {},
+      },
+    },
+  });
+
+  backend.setNetworkPolicy({ egress: "deny" });
+
+  assert.equal(resumed, true);
+  assert.equal(backend.http.qemuRxPausedForHttpStreaming, false);
+});
+
 test("qemu-net: parseHttpRequest parses content-length and preserves remaining", async () => {
   let captured: any = null;
 
@@ -2128,6 +2315,86 @@ test("qemu-net: fetchAndRespond rejects websocket upgrade requests", async () =>
   assert.equal(finished, true);
   const responseText = Buffer.concat(writes).toString("utf8");
   assert.match(responseText, /^HTTP\/1\.1 501 /);
+});
+
+test("qemu-net: websocket runtime egress deny skips DNS resolution", async () => {
+  let dnsLookups = 0;
+  const backend = makeBackend({
+    allowWebSockets: true,
+    httpHooks: {
+      onRequest() {
+        backend.setNetworkPolicy({ egress: "deny" });
+      },
+    },
+  });
+  backend.options.dnsLookup = ((_hostname: string, _options: any, cb: any) => {
+    dnsLookups += 1;
+    cb(null, [{ address: "127.0.0.1", family: 4 }]);
+  }) as any;
+
+  const key = "TCP:1.1.1.1:1234:2.2.2.2:80";
+  const session: any = {
+    socket: null,
+    srcIP: "1.1.1.1",
+    srcPort: 1234,
+    dstIP: "2.2.2.2",
+    dstPort: 80,
+    connectIP: "2.2.2.2",
+    flowControlPaused: false,
+    protocol: "http",
+    connected: false,
+    pendingWrites: [],
+    pendingWriteBytes: 0,
+  };
+  backend.tcpSessions.set(key, session);
+
+  const writes: Buffer[] = [];
+  let finished = false;
+  await qemuHttp.handleHttpDataWithWriter(
+    backend,
+    key,
+    session,
+    Buffer.from(
+      "GET /chat HTTP/1.1\r\n" +
+        "Host: example.com\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Sec-WebSocket-Key: x\r\n" +
+        "Sec-WebSocket-Version: 13\r\n" +
+        "\r\n",
+    ),
+    {
+      scheme: "http",
+      write: (chunk: Buffer) => writes.push(Buffer.from(chunk)),
+      finish: () => {
+        finished = true;
+      },
+    },
+  );
+
+  assert.equal(finished, true);
+  assert.equal(dnsLookups, 0);
+  assert.match(Buffer.concat(writes).toString("utf8"), /^HTTP\/1\.1 403 /);
+});
+
+test("qemu-net: websocket upstream connect rejects when destroyed before connect", async () => {
+  const backend = makeBackend({ webSocketUpstreamConnectTimeoutMs: 0 });
+
+  await assert.rejects(
+    qemuWs.connectWebSocketUpstream(
+      backend,
+      {
+        protocol: "http",
+        hostname: "example.com",
+        address: "192.0.2.1",
+        port: 80,
+      },
+      (socket) => {
+        setImmediate(() => socket.destroy());
+      },
+    ),
+    /closed before connect/,
+  );
 });
 
 test("qemu-net: websocket upgrades are tunneled when enabled", async () => {

--- a/host/test/vm-internals.test.ts
+++ b/host/test/vm-internals.test.ts
@@ -58,6 +58,22 @@ function makeTempResolvedServerOptions() {
   };
 }
 
+test("VM.setOutboundEgressEnabled(true) restores egress", () => {
+  let capturedPolicy: unknown = null;
+  const result = (VM.prototype.setOutboundEgressEnabled as any).call(
+    {
+      setNetworkPolicy(policy: unknown) {
+        capturedPolicy = policy;
+        return { egress: "allow" };
+      },
+    },
+    true,
+  );
+
+  assert.deepEqual(capturedPolicy, { egress: "allow" });
+  assert.deepEqual(result, { egress: "allow" });
+});
+
 function writeAssetManifest(dir: string, rootfsMode?: RootfsMode) {
   fs.writeFileSync(
     path.join(dir, "manifest.json"),

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/scripts/runtime-egress-integration.ts
+++ b/scripts/runtime-egress-integration.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { VM, type HttpHooks } from "../host/src/index.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const cliPath = path.join(repoRoot, "host/bin/gondolin.ts");
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      assert.ok(address && typeof address !== "string");
+      resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function runCli(action: "status" | "off" | "on", sessionId: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, "network", action, sessionId], {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`gondolin network ${action} timed out`));
+    }, 15_000);
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(stdout.trim());
+        return;
+      }
+      reject(
+        new Error(
+          `gondolin network ${action} failed (code=${code} signal=${signal})\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    });
+  });
+}
+
+async function curl(vm: VM): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return await vm.exec(
+    "env -u http_proxy -u HTTP_PROXY -u https_proxy -u HTTPS_PROXY -u all_proxy -u ALL_PROXY " +
+      "curl -fsS --noproxy '*' --connect-timeout 2 --max-time 5 " +
+      "--resolve runtime-egress.test:80:192.0.2.1 http://runtime-egress.test/ping",
+  );
+}
+
+async function expectCurlOk(vm: VM, expectedBody: string) {
+  const result = await curl(vm);
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.equal(result.stdout, expectedBody);
+}
+
+async function expectCurlBlocked(vm: VM) {
+  const result = await curl(vm);
+  assert.notEqual(result.exitCode, 0, "curl unexpectedly succeeded while egress was denied");
+}
+
+async function main() {
+  let upstreamHits = 0;
+  const server = http.createServer((req, res) => {
+    upstreamHits += 1;
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end(`egress-ok:${req.url}`);
+  });
+  const port = await listen(server);
+
+  const httpHooks: HttpHooks = {
+    onRequest(request) {
+      const url = new URL(request.url);
+      return new Request(`http://127.0.0.1:${port}${url.pathname}${url.search}`, {
+        method: request.method,
+      });
+    },
+  };
+
+  const vm = await VM.create({
+    httpHooks,
+    sessionLabel: "runtime-egress-integration",
+    startTimeoutMs: 120_000,
+  });
+
+  try {
+    console.log(`[1/7] starting VM ${vm.id}`);
+    await vm.start();
+
+    console.log("[2/7] default egress is allowed");
+    assert.deepEqual(vm.getNetworkPolicy(), { egress: "allow" });
+    assert.match(await runCli("status", vm.id), /egress: allow/);
+    await expectCurlOk(vm, "egress-ok:/ping");
+    assert.equal(upstreamHits, 1);
+
+    console.log("[3/7] CLI can deny egress and closes/blocks outbound flows");
+    assert.match(await runCli("off", vm.id), /egress: deny/);
+    assert.deepEqual(vm.getNetworkPolicy(), { egress: "deny" });
+    await expectCurlBlocked(vm);
+    assert.equal(upstreamHits, 1, "blocked request reached upstream server");
+
+    console.log("[4/7] CLI can re-enable egress");
+    assert.match(await runCli("on", vm.id), /egress: allow/);
+    assert.deepEqual(vm.getNetworkPolicy(), { egress: "allow" });
+    await expectCurlOk(vm, "egress-ok:/ping");
+    assert.equal(upstreamHits, 2);
+
+    console.log("[5/7] SDK can deny egress");
+    assert.deepEqual(vm.setOutboundEgressEnabled(false), { egress: "deny" });
+    await expectCurlBlocked(vm);
+    assert.equal(upstreamHits, 2, "SDK-blocked request reached upstream server");
+
+    console.log("[6/7] SDK can restore egress");
+    assert.deepEqual(vm.setOutboundEgressEnabled(true), { egress: "allow" });
+    await expectCurlOk(vm, "egress-ok:/ping");
+    assert.equal(upstreamHits, 3);
+
+    console.log("[7/7] runtime egress integration test passed");
+  } finally {
+    await vm.close().catch(() => {});
+    await closeServer(server).catch(() => {});
+  }
+}
+
+await main();


### PR DESCRIPTION
This PR adds a host-enforced runtime network egress policy for live VMs and wires it through the SDK, session control protocol, and CLI.

When egress is blocked, an HTTP 403 Forbidden status is returned for all requests that are made in the guest.

A use case for this is to fully block web access for an agent after the agent's context has been populated with personal data, which we would not want to risk being exfiltrated.