### PR TITLE
feat(vm): Auto pause

### DIFF
--- a/host/src/qemu/net.ts
+++ b/host/src/qemu/net.ts
@@ -155,6 +155,34 @@ type TlsSession = {
   servername: string | null;
 };
 
+class ActivityMap<K, V> extends Map<K, V> {
+  private readonly onActivityChange: () => void;
+
+  constructor(onActivityChange: () => void) {
+    super();
+    this.onActivityChange = onActivityChange;
+  }
+
+  override set(key: K, value: V): this {
+    const hadKey = this.has(key);
+    super.set(key, value);
+    if (!hadKey) this.onActivityChange();
+    return this;
+  }
+
+  override delete(key: K): boolean {
+    const deleted = super.delete(key);
+    if (deleted) this.onActivityChange();
+    return deleted;
+  }
+
+  override clear(): void {
+    if (this.size === 0) return;
+    super.clear();
+    this.onActivityChange();
+  }
+}
+
 export type TcpSession = {
   socket: net.Socket | null;
   srcIP: string;
@@ -315,9 +343,12 @@ export class QemuNetworkBackend extends EventEmitter {
   stack: NetworkStack | null = null;
 
   private readonly udpSessions = new Map<string, UdpSession>();
+  private guestActivityActive = false;
 
   /** @internal */
-  readonly tcpSessions = new Map<string, TcpSession>();
+  readonly tcpSessions = new ActivityMap<string, TcpSession>(() =>
+    this.notifyGuestActivityChange(),
+  );
 
   private readonly mitmDir: string;
   private caPromise: Promise<CaCert> | null = null;
@@ -443,6 +474,17 @@ export class QemuNetworkBackend extends EventEmitter {
       dnsMode: this.dnsMode,
       syntheticHostMapping: this.syntheticDnsHostMapping,
     });
+  }
+
+  hasActiveGuestActivity(): boolean {
+    return this.tcpSessions.size > 0;
+  }
+
+  private notifyGuestActivityChange() {
+    const active = this.hasActiveGuestActivity();
+    if (active === this.guestActivityActive) return;
+    this.guestActivityActive = active;
+    this.emit("guest-activity-change", active);
   }
 
   start() {

--- a/host/src/sandbox/controller.ts
+++ b/host/src/sandbox/controller.ts
@@ -2,6 +2,9 @@ import { EventEmitter } from "events";
 import child_process from "child_process";
 import type { ChildProcess } from "child_process";
 import fs from "fs";
+import net from "net";
+import path from "path";
+import { randomUUID } from "crypto";
 
 const activeChildren = new Set<ChildProcess>();
 let exitHookRegistered = false;
@@ -32,6 +35,191 @@ function trackChild(child: ChildProcess) {
   };
   child.once("exit", cleanup);
   child.once("error", cleanup);
+}
+
+const QMP_COMMAND_TIMEOUT_MS = 2000;
+
+type QmpCommand = "stop" | "cont" | "query-status";
+
+type QmpErrorReason =
+  | "timeout"
+  | "closed"
+  | "socket_error"
+  | "qmp_error"
+  | "invalid_response";
+
+class QmpCommandError extends Error {
+  readonly command: QmpCommand;
+  readonly reason: QmpErrorReason;
+  readonly commandSent: boolean;
+
+  constructor(
+    command: QmpCommand,
+    reason: QmpErrorReason,
+    message: string,
+    commandSent: boolean,
+  ) {
+    super(message);
+    this.name = "QmpCommandError";
+    this.command = command;
+    this.reason = reason;
+    this.commandSent = commandSent;
+  }
+}
+
+function isUnknownQmpOutcome(err: unknown) {
+  return (
+    err instanceof QmpCommandError &&
+    err.commandSent &&
+    err.reason !== "qmp_error"
+  );
+}
+
+type QmpMessage = {
+  QMP?: unknown;
+  return?: unknown;
+  error?: {
+    class?: string;
+    desc?: string;
+  };
+  event?: string;
+};
+
+function formatQmpError(command: QmpCommand, message: QmpMessage) {
+  const errorClass = message.error?.class;
+  const desc = message.error?.desc ?? "unknown qmp error";
+  return errorClass
+    ? `qmp ${command} failed (${errorClass}): ${desc}`
+    : `qmp ${command} failed: ${desc}`;
+}
+
+function executeQmpCommand(
+  socketPath: string,
+  command: QmpCommand,
+): Promise<unknown> {
+  return new Promise<unknown>((resolve, reject) => {
+    let done = false;
+    let buffer = "";
+    let commandSent = false;
+    let stage: "greeting" | "capabilities" | "command" = "greeting";
+
+    const socket = net.createConnection(socketPath);
+    socket.setEncoding("utf8");
+    let timer: NodeJS.Timeout;
+
+    const finish = (err?: Error, value?: unknown) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      socket.removeAllListeners();
+      socket.destroy();
+      if (err) reject(err);
+      else resolve(value);
+    };
+
+    timer = setTimeout(() => {
+      finish(
+        new QmpCommandError(
+          command,
+          "timeout",
+          `qmp ${command} timed out`,
+          commandSent,
+        ),
+      );
+    }, QMP_COMMAND_TIMEOUT_MS);
+    timer.unref?.();
+
+    const send = (message: object) => {
+      socket.write(`${JSON.stringify(message)}\r\n`);
+    };
+
+    const handleMessage = (message: QmpMessage) => {
+      if (message.error) {
+        finish(
+          new QmpCommandError(
+            command,
+            "qmp_error",
+            formatQmpError(command, message),
+            commandSent,
+          ),
+        );
+        return;
+      }
+
+      if (stage === "greeting") {
+        if (!message.QMP) return;
+        stage = "capabilities";
+        send({ execute: "qmp_capabilities" });
+        return;
+      }
+
+      if (stage === "capabilities") {
+        if (!Object.hasOwn(message, "return")) return;
+        stage = "command";
+        commandSent = true;
+        send({ execute: command });
+        return;
+      }
+
+      if (Object.hasOwn(message, "return")) {
+        finish(undefined, message.return);
+      }
+    };
+
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      for (;;) {
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) break;
+        const raw = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (!raw) continue;
+
+        let message: QmpMessage;
+        try {
+          message = JSON.parse(raw) as QmpMessage;
+        } catch {
+          finish(
+            new QmpCommandError(
+              command,
+              "invalid_response",
+              `invalid qmp response for ${command}`,
+              commandSent,
+            ),
+          );
+          return;
+        }
+
+        handleMessage(message);
+        if (done) return;
+      }
+    });
+
+    socket.on("error", (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      finish(
+        new QmpCommandError(command, "socket_error", message, commandSent),
+      );
+    });
+
+    socket.on("close", () => {
+      finish(
+        new QmpCommandError(
+          command,
+          "closed",
+          `qmp ${command} connection closed`,
+          commandSent,
+        ),
+      );
+    });
+  });
+}
+
+function defaultQmpSocketPath(config: SandboxConfig) {
+  return path.join(
+    path.resolve(path.dirname(config.virtioSocketPath)),
+    `gondolin-qmp-${randomUUID().slice(0, 8)}.sock`,
+  );
 }
 
 export type SandboxConfig = {
@@ -82,6 +270,10 @@ export type SandboxConfig = {
   netSocketPath?: string;
   /** guest mac address */
   netMac?: string;
+  /** qemu monitor socket path */
+  qmpSocketPath?: string;
+  /** qemu idle pause timeout in `ms` */
+  qemuIdlePauseMs?: number;
   /** whether to restart the vm automatically on exit */
   autoRestart: boolean;
 };
@@ -94,12 +286,35 @@ export class SandboxController extends EventEmitter {
   private child: ChildProcess | null = null;
   private state: SandboxState = "stopped";
   private restartTimer: NodeJS.Timeout | null = null;
+  private idleTimer: NodeJS.Timeout | null = null;
   private manualStop = false;
+  private paused = false;
+  private pauseInProgress = false;
+  private qmpIdleDisabled = false;
+  private qmpChain: Promise<void> = Promise.resolve();
+  private qmpGeneration = 0;
   private readonly config: SandboxConfig;
+  private readonly qmpSocketPath: string | null;
+  private readonly idlePauseMs: number | null;
 
   constructor(config: SandboxConfig) {
     super();
     this.config = config;
+
+    if (
+      config.qemuIdlePauseMs !== undefined &&
+      (!Number.isFinite(config.qemuIdlePauseMs) || config.qemuIdlePauseMs < 0)
+    ) {
+      throw new Error(
+        `invalid qemu idle pause timeout: ${config.qemuIdlePauseMs}`,
+      );
+    }
+
+    const idlePauseMs = Math.trunc(config.qemuIdlePauseMs ?? 0);
+    this.idlePauseMs = idlePauseMs > 0 ? idlePauseMs : null;
+    this.qmpSocketPath = this.idlePauseMs
+      ? (config.qmpSocketPath ?? defaultQmpSocketPath(config))
+      : null;
   }
 
   setAppend(append: string) {
@@ -113,10 +328,21 @@ export class SandboxController extends EventEmitter {
   async start() {
     if (this.child) return;
 
+    this.cancelIdlePause();
+    this.qmpGeneration += 1;
+    this.paused = false;
+    this.pauseInProgress = false;
+    this.qmpIdleDisabled = false;
+    this.qmpChain = Promise.resolve();
     this.manualStop = false;
     this.setState("starting");
 
-    const args = buildQemuArgs(this.config);
+    this.cleanupQmpSocket();
+
+    const args = buildQemuArgs({
+      ...this.config,
+      qmpSocketPath: this.qmpSocketPath ?? undefined,
+    });
     this.child = child_process.spawn(this.config.qemuPath, args, {
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -135,12 +361,22 @@ export class SandboxController extends EventEmitter {
     });
 
     this.child.on("error", (err) => {
+      this.cancelIdlePause();
+      this.qmpGeneration += 1;
+      this.cleanupQmpSocket();
+      this.paused = false;
+      this.pauseInProgress = false;
       this.child = null;
       this.setState("stopped");
       this.emit("exit", { code: null, signal: null, error: err });
     });
 
     this.child.on("exit", (code, signal) => {
+      this.cancelIdlePause();
+      this.qmpGeneration += 1;
+      this.cleanupQmpSocket();
+      this.paused = false;
+      this.pauseInProgress = false;
       this.child = null;
       this.setState("stopped");
       this.emit("exit", { code, signal });
@@ -155,7 +391,12 @@ export class SandboxController extends EventEmitter {
   }
 
   async close() {
-    if (!this.child) return;
+    this.cancelIdlePause();
+    this.qmpGeneration += 1;
+    if (!this.child) {
+      this.cleanupQmpSocket();
+      return;
+    }
     const child = this.child;
     this.child = null;
     this.manualStop = true;
@@ -272,7 +513,165 @@ export class SandboxController extends EventEmitter {
       if (errorHandler) child.off("error", errorHandler);
     }
 
+    this.cleanupQmpSocket();
+    this.paused = false;
+    this.pauseInProgress = false;
+    this.qmpChain = Promise.resolve();
     this.setState("stopped");
+  }
+
+  resumeForActivity(): Promise<void> | void {
+    if (!this.qmpSocketPath) return;
+    this.cancelIdlePause();
+    if (!this.paused && !this.pauseInProgress) return;
+    return this.resumeForActivityAsync(this.qmpGeneration, this.child);
+  }
+
+  private async resumeForActivityAsync(
+    generation: number,
+    child: ChildProcess | null,
+  ): Promise<void> {
+    try {
+      await this.runQmpCommand("cont");
+    } catch (err) {
+      if (!this.isCurrentQmpGeneration(generation, child)) return;
+      const running = await this.queryQmpRunning(generation, child);
+      if (!this.isCurrentQmpGeneration(generation, child)) return;
+      if (running !== true) throw err;
+    }
+
+    if (!this.isCurrentQmpGeneration(generation, child)) return;
+    this.paused = false;
+    this.pauseInProgress = false;
+  }
+
+  scheduleIdlePause() {
+    if (
+      !this.qmpSocketPath ||
+      this.qmpIdleDisabled ||
+      !this.child ||
+      this.state !== "running" ||
+      this.paused ||
+      this.pauseInProgress
+    ) {
+      return;
+    }
+
+    this.cancelIdlePause();
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      void this.pauseForIdle();
+    }, this.idlePauseMs!);
+    this.idleTimer.unref?.();
+  }
+
+  cancelIdlePause() {
+    if (!this.idleTimer) return;
+    clearTimeout(this.idleTimer);
+    this.idleTimer = null;
+  }
+
+  private async pauseForIdle() {
+    if (
+      !this.qmpSocketPath ||
+      this.qmpIdleDisabled ||
+      !this.child ||
+      this.state !== "running" ||
+      this.paused ||
+      this.pauseInProgress
+    ) {
+      return;
+    }
+
+    const generation = this.qmpGeneration;
+    const child = this.child;
+
+    this.pauseInProgress = true;
+    try {
+      await this.runQmpCommand("stop");
+      if (!this.isCurrentQmpGeneration(generation, child)) return;
+      if (this.child && this.state === "running") {
+        this.paused = true;
+      }
+    } catch (err) {
+      if (!this.isCurrentQmpGeneration(generation, child)) return;
+      const mayBePaused = isUnknownQmpOutcome(err);
+      this.qmpIdleDisabled = true;
+      if (mayBePaused && this.child && this.state === "running") {
+        this.paused = true;
+        try {
+          const resume = this.resumeForActivity();
+          if (resume) await resume;
+        } catch {
+          // Keep paused=true so later activity keeps retrying QMP cont.
+        }
+      }
+
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit(
+        "log",
+        `qmp idle pause disabled: ${message}\n`,
+        "stderr" satisfies SandboxLogStream,
+      );
+    } finally {
+      if (this.isCurrentQmpGeneration(generation, child)) {
+        this.pauseInProgress = false;
+      }
+    }
+  }
+
+  private isCurrentQmpGeneration(
+    generation: number,
+    child: ChildProcess | null,
+  ) {
+    return this.qmpGeneration === generation && this.child === child;
+  }
+
+  private async queryQmpRunning(
+    generation: number,
+    child: ChildProcess | null,
+  ): Promise<boolean | null> {
+    try {
+      const result = await this.runQmpCommand("query-status");
+      if (!this.isCurrentQmpGeneration(generation, child)) return null;
+      if (result && typeof result === "object") {
+        const status = result as { running?: unknown; status?: unknown };
+        if (typeof status.running === "boolean") return status.running;
+        if (status.status === "running") return true;
+        if (status.status === "paused") return false;
+      }
+    } catch {
+      // ignore query-status failures; callers decide how to handle unknown state
+    }
+    return null;
+  }
+
+  private async runQmpCommand(command: QmpCommand): Promise<unknown> {
+    if (!this.qmpSocketPath) return;
+
+    const run = this.qmpChain
+      .catch(() => {
+        // keep the command chain alive after a failed command
+      })
+      .then(() => executeQmpCommand(this.qmpSocketPath!, command));
+    this.qmpChain = run.then(
+      () => {
+        // keep the command chain alive after a completed command
+      },
+      () => {
+        // keep the command chain alive after a failed command
+      },
+    );
+    return await run;
+  }
+
+  private cleanupQmpSocket() {
+    if (!this.qmpSocketPath) return;
+    try {
+      fs.rmSync(this.qmpSocketPath, { force: true });
+    } catch {
+      // ignore
+    }
   }
 
   async restart() {
@@ -410,6 +809,10 @@ function buildQemuArgs(config: SandboxConfig) {
     );
     const mac = config.netMac ?? "02:00:00:00:00:01";
     args.push("-device", `${netDev},netdev=net0,mac=${mac}`);
+  }
+
+  if (config.qmpSocketPath) {
+    args.push("-qmp", `unix:${config.qmpSocketPath},server=on,wait=off`);
   }
 
   return args;

--- a/host/src/sandbox/server-ops.ts
+++ b/host/src/sandbox/server-ops.ts
@@ -80,6 +80,39 @@ export class SandboxServerOps {
     return this.fsService?.metrics ?? null;
   }
 
+  resumeControllerForActivity(): Promise<void> | void {
+    return this.controller.resumeForActivity?.();
+  }
+
+  hasActiveGuestActivity(): boolean {
+    return (
+      this.inflight.size > 0 ||
+      this.startedExecs.size > 0 ||
+      this.execQueue.length > 0 ||
+      this.fileOps.size > 0 ||
+      this.activeFileOpId !== null ||
+      this.activeVfsRequests > 0 ||
+      Boolean(this.network?.hasActiveGuestActivity()) ||
+      this.tcpStreams.size > 0 ||
+      this.tcpOpenWaiters.size > 0 ||
+      this.ingressTcpStreams.size > 0 ||
+      this.ingressTcpOpenWaiters.size > 0
+    );
+  }
+
+  execPressure(): number {
+    let pressure = this.startedExecs.size;
+    for (const id of this.inflight.keys()) {
+      if (!this.startedExecs.has(id)) pressure += 1;
+    }
+    return pressure;
+  }
+
+  scheduleControllerIdlePause(): void {
+    if (this.hasActiveGuestActivity()) return;
+    this.controller.scheduleIdlePause?.();
+  }
+
   connect(
     onMessage: (data: Buffer | string, isBinary: boolean) => void,
     onClose?: () => void,
@@ -351,6 +384,8 @@ export class SandboxServerOps {
       throw new Error(`invalid guest port: ${port}`);
     }
 
+    await this.resumeControllerForActivity();
+
     // Allocate stream id
     let id = this.nextTcpStreamId;
     for (let i = 0; i < 0xffffffff; i++) {
@@ -371,6 +406,7 @@ export class SandboxServerOps {
           this.tcpOpenWaiters.delete(id);
           waiter.reject(new Error("tcp stream closed"));
         }
+        this.scheduleControllerIdlePause();
       },
     );
 
@@ -394,6 +430,7 @@ export class SandboxServerOps {
       this.tcpStreams.delete(id);
       this.tcpOpenWaiters.delete(id);
       stream.destroy();
+      this.scheduleControllerIdlePause();
       throw new Error("virtio tcp queue exceeded");
     }
 
@@ -411,6 +448,7 @@ export class SandboxServerOps {
       return stream;
     } catch (err) {
       stream.destroy(err instanceof Error ? err : new Error(String(err)));
+      this.scheduleControllerIdlePause();
       throw err;
     } finally {
       if (timeout) clearTimeout(timeout);
@@ -440,6 +478,8 @@ export class SandboxServerOps {
       throw new Error(`invalid guest port: ${port}`);
     }
 
+    await this.resumeControllerForActivity();
+
     // Allocate stream id
     let id = this.nextIngressTcpStreamId;
     for (let i = 0; i < 0xffffffff; i++) {
@@ -464,6 +504,7 @@ export class SandboxServerOps {
           this.ingressTcpOpenWaiters.delete(id);
           waiter.reject(new Error("tcp stream closed"));
         }
+        this.scheduleControllerIdlePause();
       },
     );
 
@@ -487,6 +528,7 @@ export class SandboxServerOps {
       this.ingressTcpStreams.delete(id);
       this.ingressTcpOpenWaiters.delete(id);
       stream.destroy();
+      this.scheduleControllerIdlePause();
       throw new Error("virtio tcp queue exceeded");
     }
 
@@ -504,6 +546,7 @@ export class SandboxServerOps {
       return stream;
     } catch (err) {
       stream.destroy(err instanceof Error ? err : new Error(String(err)));
+      this.scheduleControllerIdlePause();
       throw err;
     } finally {
       if (timeout) clearTimeout(timeout);
@@ -534,6 +577,7 @@ export class SandboxServerOps {
       this.status = "running";
       this.broadcastStatus(this.status);
     }
+    this.scheduleControllerIdlePause();
   }
 
   handleVfsError(message: string, code = "vfs_error") {
@@ -578,6 +622,7 @@ export class SandboxServerOps {
   }
 
   async closeInternal() {
+    this.controller.cancelIdlePause?.();
     this.failInflight("server_shutdown", "server is shutting down");
     this.closeAllClients();
 
@@ -657,6 +702,7 @@ export class SandboxServerOps {
 
   async waitForExecIdle(signal?: AbortSignal): Promise<void> {
     while (
+      this.inflight.size > 0 ||
       this.startedExecs.size > 0 ||
       this.activeFileOpId !== null ||
       this.execQueue.length > 0
@@ -719,7 +765,15 @@ export class SandboxServerOps {
     message: object,
     signal?: AbortSignal,
   ): Promise<void> {
-    while (!this.bridge.send(message)) {
+    if (signal?.aborted) {
+      throw new Error("operation aborted");
+    }
+    await this.resumeControllerForActivity();
+    for (;;) {
+      if (signal?.aborted) {
+        throw new Error("operation aborted");
+      }
+      if (this.bridge.send(message)) return;
       await this.waitForBridgeWritable(signal);
     }
   }
@@ -739,6 +793,7 @@ export class SandboxServerOps {
       this.activeFileOpId = null;
       this.pumpExecQueue();
     }
+    this.scheduleControllerIdlePause();
   }
 
   rejectFileOperation(id: number, err: Error): void {
@@ -758,6 +813,7 @@ export class SandboxServerOps {
       this.activeFileOpId = null;
       this.pumpExecQueue();
     }
+    this.scheduleControllerIdlePause();
   }
 
   failFileOperations(message: string): void {
@@ -773,6 +829,7 @@ export class SandboxServerOps {
     for (const [id, entry] of this.inflight.entries()) {
       if (entry === client) {
         this.inflight.delete(id);
+        this.pendingExecAdmissions.delete(id);
         this.stdinAllowed.delete(id);
         this.stdinCredits.delete(id);
         this.pendingExecWindows.delete(id);
@@ -834,7 +891,7 @@ export class SandboxServerOps {
     }
 
     if (message.type === "exec") {
-      this.handleExec(client, message);
+      void this.handleExec(client, message);
     } else if (message.type === "stdin") {
       this.handleStdin(client, message);
     } else if (message.type === "pty_resize") {
@@ -919,6 +976,7 @@ export class SandboxServerOps {
 
     if (!this.bridge.send(buildExecRequest(id, entry.payload))) {
       this.inflight.delete(id);
+      this.pendingExecAdmissions.delete(id);
       this.startedExecs.delete(id);
       this.stdinAllowed.delete(id);
       this.stdinCredits.delete(id);
@@ -931,6 +989,7 @@ export class SandboxServerOps {
         code: "queue_full",
         message: "virtio bridge queue exceeded",
       });
+      this.scheduleControllerIdlePause();
       return;
     }
 
@@ -970,7 +1029,7 @@ export class SandboxServerOps {
     }
   }
 
-  handleExec(client: SandboxClient, message: ExecCommandMessage) {
+  async handleExec(client: SandboxClient, message: ExecCommandMessage) {
     if (this.hasDebug("exec")) {
       const envKeys = (message.env ?? [])
         .map((entry) => String(entry).split("=", 1)[0])
@@ -1029,8 +1088,7 @@ export class SandboxServerOps {
       return;
     }
 
-    const execPressure = this.startedExecs.size + this.execQueue.length;
-    if (execPressure >= this.options.maxQueuedExecs) {
+    if (this.execPressure() >= this.options.maxQueuedExecs) {
       sendError(client, {
         type: "error",
         id: message.id,
@@ -1040,11 +1098,54 @@ export class SandboxServerOps {
       return;
     }
 
+    const admission = {};
     this.inflight.set(message.id, client);
+    this.pendingExecAdmissions.set(message.id, admission);
     if (message.stdin) {
       this.stdinAllowed.add(message.id);
       this.stdinCredits.set(message.id, 0);
     }
+
+    try {
+      const resume = this.resumeControllerForActivity();
+      if (resume) await resume;
+    } catch (err) {
+      const ownsAdmission =
+        this.pendingExecAdmissions.get(message.id) === admission;
+      const owner = ownsAdmission ? this.inflight.get(message.id) : undefined;
+      if (ownsAdmission) {
+        this.inflight.delete(message.id);
+        this.pendingExecAdmissions.delete(message.id);
+        this.stdinAllowed.delete(message.id);
+        this.stdinCredits.delete(message.id);
+        this.pendingExecWindows.delete(message.id);
+        this.clearQueuedStdin(message.id);
+        this.queuedPtyResize.delete(message.id);
+      }
+
+      if (owner) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        sendError(owner, {
+          type: "error",
+          id: message.id,
+          code: "sandbox_resume_failed",
+          message: error.message,
+        });
+      }
+      this.scheduleControllerIdlePause();
+      return;
+    }
+
+    const ownsAdmission =
+      this.pendingExecAdmissions.get(message.id) === admission;
+    if (!ownsAdmission || this.inflight.get(message.id) !== client) {
+      if (ownsAdmission) {
+        this.pendingExecAdmissions.delete(message.id);
+      }
+      this.scheduleControllerIdlePause();
+      return;
+    }
+    this.pendingExecAdmissions.delete(message.id);
 
     const payload = {
       cmd: message.cmd,
@@ -1157,6 +1258,7 @@ export class SandboxServerOps {
           // Cancel queued execs on stdin overflow to avoid running with partial
           // stdin once file-operation gating is lifted.
           this.inflight.delete(message.id);
+          this.pendingExecAdmissions.delete(message.id);
           this.startedExecs.delete(message.id);
           this.stdinAllowed.delete(message.id);
           this.stdinCredits.delete(message.id);
@@ -1512,6 +1614,7 @@ export class SandboxServerOps {
       });
     }
     this.inflight.clear();
+    this.pendingExecAdmissions.clear();
     this.startedExecs.clear();
     this.stdinAllowed.clear();
     this.pendingExecWindows.clear();

--- a/host/src/sandbox/server-options.ts
+++ b/host/src/sandbox/server-options.ts
@@ -51,6 +51,7 @@ const DEFAULT_MAX_STDIN_BYTES = 64 * 1024;
 const DEFAULT_MAX_QUEUED_STDIN_BYTES = 8 * 1024 * 1024;
 const DEFAULT_MAX_TOTAL_QUEUED_STDIN_BYTES = 32 * 1024 * 1024;
 const DEFAULT_MAX_QUEUED_EXECS = 64;
+const DEFAULT_DARWIN_HVF_IDLE_PAUSE_MS = 30_000;
 
 /**
  * sandbox server options
@@ -131,6 +132,8 @@ export type SandboxServerOptions = {
   console?: "stdio" | "none";
   /** whether to restart the vm automatically on exit */
   autoRestart?: boolean;
+  /** qemu idle pause timeout in `ms` (`0` disables) */
+  qemuIdlePauseMs?: number;
   /** kernel cmdline append string */
   append?: string;
 
@@ -221,6 +224,8 @@ export type ResolvedSandboxServerOptions = {
   console?: "stdio" | "none";
   /** whether to restart the vm automatically on exit */
   autoRestart: boolean;
+  /** qemu idle pause timeout in `ms` (`undefined` disables) */
+  qemuIdlePauseMs?: number;
   /** kernel cmdline append string */
   append?: string;
 
@@ -343,6 +348,37 @@ function detectQemuArch(qemuPath: string): "arm64" | "x64" | null {
   )
     return "x64";
   return null;
+}
+
+function normalizeQemuIdlePauseMs(value: number): number | undefined {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`invalid qemu idle pause timeout: ${value}`);
+  }
+  const ms = Math.trunc(value);
+  return ms > 0 ? ms : undefined;
+}
+
+function resolveQemuIdlePauseMs(
+  options: SandboxServerOptions,
+  vmm: SandboxVmm,
+): number | undefined {
+  if (options.qemuIdlePauseMs !== undefined) {
+    return normalizeQemuIdlePauseMs(options.qemuIdlePauseMs);
+  }
+
+  if (vmm !== "qemu" || process.platform !== "darwin") {
+    return undefined;
+  }
+
+  const accelName = (options.accel ?? "")
+    .split(",", 1)[0]!
+    .trim()
+    .toLowerCase();
+  if (accelName && accelName !== "hvf") {
+    return undefined;
+  }
+
+  return DEFAULT_DARWIN_HVF_IDLE_PAUSE_MS;
 }
 
 function resolveLocalKrunRunnerPath(): string | null {
@@ -866,6 +902,8 @@ export function resolveSandboxServerOptions(
       unsupported.push("sandbox.machineType");
     if (options.accel !== undefined) unsupported.push("sandbox.accel");
     if (options.cpu !== undefined) unsupported.push("sandbox.cpu");
+    if (options.qemuIdlePauseMs !== undefined)
+      unsupported.push("sandbox.qemuIdlePauseMs");
 
     if (unsupported.length > 0) {
       throw new Error(
@@ -993,6 +1031,7 @@ export function resolveSandboxServerOptions(
     cpu,
     console: options.console,
     autoRestart: options.autoRestart ?? false,
+    qemuIdlePauseMs: resolveQemuIdlePauseMs(options, vmm),
     append: options.append,
     maxStdinBytes,
     maxQueuedStdinBytes,

--- a/host/src/sandbox/server.ts
+++ b/host/src/sandbox/server.ts
@@ -111,6 +111,9 @@ type SandboxControllerLike = {
   start(): Promise<void>;
   close(): Promise<void>;
   restart(): Promise<void>;
+  resumeForActivity?(): Promise<void> | void;
+  scheduleIdlePause?(): void;
+  cancelIdlePause?(): void;
   on(event: "state", listener: (state: SandboxState) => void): unknown;
   on(
     event: "log",
@@ -242,9 +245,13 @@ export class SandboxServer extends EventEmitter {
   private readonly baseAppend: string;
   private vfsProvider: SandboxVfsProvider | null;
   private fsService: FsRpcService | null = null;
+  /** VFS requests currently executing in the host filesystem service */
+  private activeVfsRequests = 0;
   private clients = new Set<SandboxClient>();
   private inflight = new Map<number, SandboxClient>();
   private stdinAllowed = new Set<number>();
+  /** exec admission tokens while host-side async resume is pending */
+  private pendingExecAdmissions = new Map<number, object>();
 
   // Exec requests that are accepted by the host API but not yet started on the
   // guest control channel (currently only used while a file operation is active)
@@ -426,6 +433,7 @@ export class SandboxServer extends EventEmitter {
         accel: this.options.accel,
         cpu: this.options.cpu,
         console: this.options.console,
+        qemuIdlePauseMs: this.options.qemuIdlePauseMs,
         autoRestart: this.options.autoRestart,
       };
       this.controller = new SandboxController(sandboxConfig);
@@ -495,6 +503,25 @@ export class SandboxServer extends EventEmitter {
       this.network.on("error", (err) => {
         this.emit("error", err);
       });
+      this.network.on("guest-activity-change", (active: boolean) => {
+        if (active) {
+          const resume = this.resumeControllerForActivity();
+          if (resume) {
+            void resume
+              .catch((err: unknown) => {
+                this.emit(
+                  "error",
+                  err instanceof Error ? err : new Error(String(err)),
+                );
+              })
+              .finally(() => {
+                this.scheduleControllerIdlePause();
+              });
+          }
+        } else {
+          this.scheduleControllerIdlePause();
+        }
+      });
     }
 
     this.controller.on("state", (state) => {
@@ -539,6 +566,9 @@ export class SandboxServer extends EventEmitter {
       }
 
       this.broadcastStatus(this.status);
+      if (this.status === "running") {
+        this.scheduleControllerIdlePause();
+      }
     });
 
     this.controller.on("exit", (info) => {
@@ -693,6 +723,7 @@ export class SandboxServer extends EventEmitter {
         this.pendingExecWindows.delete(message.id);
         this.clearQueuedStdin(message.id);
         this.queuedPtyResize.delete(message.id);
+        this.scheduleControllerIdlePause();
       } else if (message.t === "stdin_window") {
         const stdin = (message as any).p?.stdin;
         const credits = Number(stdin);
@@ -779,6 +810,7 @@ export class SandboxServer extends EventEmitter {
             new Error(`${message.p.code}: ${message.p.message}`),
           );
         }
+        this.scheduleControllerIdlePause();
       } else if (message.t === "vfs_ready") {
         this.handleVfsReady();
       } else if (message.t === "vfs_error") {
@@ -802,28 +834,32 @@ export class SandboxServer extends EventEmitter {
       if (message.t !== "fs_request") {
         return;
       }
-      if (!this.fsService) {
-        this.fsBridge.send({
-          v: 1,
-          t: "fs_response",
-          id: message.id,
-          p: {
-            op: message.p.op,
-            err: LINUX_ERRNO.ENOSYS,
-            message: "filesystem service unavailable",
-          },
-        });
-        return;
-      }
+      this.controller.cancelIdlePause?.();
+      this.activeVfsRequests += 1;
+      void (async () => {
+        try {
+          const resume = this.resumeControllerForActivity();
+          if (resume) await resume;
 
-      void this.fsService
-        .handleRequest(message)
-        .then((response) => {
+          if (!this.fsService) {
+            this.fsBridge.send({
+              v: 1,
+              t: "fs_response",
+              id: message.id,
+              p: {
+                op: message.p.op,
+                err: LINUX_ERRNO.ENOSYS,
+                message: "filesystem service unavailable",
+              },
+            });
+            return;
+          }
+
+          const response = await this.fsService.handleRequest(message);
           if (!this.fsBridge.send(response)) {
             this.emit("error", new Error("[fs] virtio bridge queue exceeded"));
           }
-        })
-        .catch((err) => {
+        } catch (err) {
           const detail =
             err instanceof Error ? err.message : "fs handler error";
           this.fsBridge.send({
@@ -837,7 +873,11 @@ export class SandboxServer extends EventEmitter {
             },
           });
           this.emit("error", err instanceof Error ? err : new Error(detail));
-        });
+        } finally {
+          this.activeVfsRequests = Math.max(0, this.activeVfsRequests - 1);
+          this.scheduleControllerIdlePause();
+        }
+      })();
     };
 
     this.sshBridge.onMessage = (message: any) => {
@@ -875,6 +915,7 @@ export class SandboxServer extends EventEmitter {
           stream?.openFailed(msg);
           this.tcpStreams.delete(message.id);
           waiter.reject(new Error(msg));
+          this.scheduleControllerIdlePause();
         }
         return;
       }
@@ -898,6 +939,7 @@ export class SandboxServer extends EventEmitter {
           waiter.reject(new Error("tcp stream closed"));
         }
         stream.remoteClose();
+        this.scheduleControllerIdlePause();
         return;
       }
     };
@@ -914,6 +956,7 @@ export class SandboxServer extends EventEmitter {
         stream.destroy(new Error("ssh virtio bridge error"));
       }
       this.tcpStreams.clear();
+      this.scheduleControllerIdlePause();
     };
 
     this.ingressBridge.onMessage = (message: any) => {
@@ -951,6 +994,7 @@ export class SandboxServer extends EventEmitter {
           stream?.openFailed(msg);
           this.ingressTcpStreams.delete(message.id);
           waiter.reject(new Error(msg));
+          this.scheduleControllerIdlePause();
         }
         return;
       }
@@ -974,6 +1018,7 @@ export class SandboxServer extends EventEmitter {
           waiter.reject(new Error("tcp stream closed"));
         }
         stream.remoteClose();
+        this.scheduleControllerIdlePause();
         return;
       }
     };
@@ -993,6 +1038,7 @@ export class SandboxServer extends EventEmitter {
         stream.destroy(new Error("ingress virtio bridge error"));
       }
       this.ingressTcpStreams.clear();
+      this.scheduleControllerIdlePause();
     };
 
     this.bridge.onError = (err) => {

--- a/host/test/sandbox-controller.test.ts
+++ b/host/test/sandbox-controller.test.ts
@@ -68,16 +68,6 @@ async function waitFor(
   assert.equal(predicate(), true);
 }
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (err: Error) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
 afterEach(() => {
   mock.restoreAll();
   mock.timers.reset();
@@ -143,9 +133,8 @@ test("buildQemuArgs: rootDiskVolatileMode=snapshot enables qemu snapshot mode", 
   assert.match(args[driveIndex + 1]!, /snapshot=on/);
 });
 
-test("SandboxController: idle pause uses QMP stop/cont", async () => {
+test("SandboxController: idle pause uses a short QMP socket", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-qmp-test-"));
-  const qmpSocketPath = path.join(tmpDir, "qmp.sock");
   const seenCommands: string[] = [];
   const child = new FakeChildProcess();
   let spawnedArgs: string[] = [];
@@ -156,7 +145,10 @@ test("SandboxController: idle pause uses QMP stop/cont", async () => {
   });
 
   const controller = new SandboxController(
-    makeConfig({ qemuIdlePauseMs: 1, qmpSocketPath }),
+    makeConfig({
+      qemuIdlePauseMs: 1,
+      virtioSocketPath: path.join(tmpDir, "virtio.sock"),
+    }),
   );
 
   const server = net.createServer((socket) => {
@@ -185,8 +177,14 @@ test("SandboxController: idle pause uses QMP stop/cont", async () => {
     await controller.start();
     child.emit("spawn");
 
-    assert.ok(spawnedArgs.includes("-qmp"));
-    assert.ok(spawnedArgs.includes(`unix:${qmpSocketPath},server=on,wait=off`));
+    const qmpIndex = spawnedArgs.indexOf("-qmp");
+    assert.notEqual(qmpIndex, -1);
+    const match = /^unix:(.*),server=on,wait=off$/.exec(
+      spawnedArgs[qmpIndex + 1]!,
+    );
+    assert.ok(match);
+    const qmpSocketPath = match[1]!;
+    assert.equal(path.dirname(qmpSocketPath), tmpDir);
 
     await new Promise<void>((resolve, reject) => {
       server.once("error", reject);
@@ -199,8 +197,8 @@ test("SandboxController: idle pause uses QMP stop/cont", async () => {
     controller.scheduleIdlePause();
     await waitFor(() => seenCommands.includes("stop"));
 
-    await controller.resumeForActivity();
-    await waitFor(() => seenCommands.includes("cont"));
+    const resume = controller.resumeForActivity();
+    if (resume) await resume;
 
     assert.deepEqual(
       seenCommands.filter(
@@ -216,188 +214,6 @@ test("SandboxController: idle pause uses QMP stop/cont", async () => {
     if (server.listening) {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("SandboxController: failed QMP stop sends best-effort cont", async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-qmp-test-"));
-  const qmpSocketPath = path.join(tmpDir, "qmp.sock");
-  const seenCommands: string[] = [];
-  const child = new FakeChildProcess();
-
-  mock.method(cp, "spawn", () => child as any);
-
-  const controller = new SandboxController(
-    makeConfig({ qemuIdlePauseMs: 1, qmpSocketPath }),
-  );
-
-  const server = net.createServer((socket) => {
-    socket.setEncoding("utf8");
-    socket.write(
-      JSON.stringify({ QMP: { version: {}, capabilities: [] } }) + "\r\n",
-    );
-
-    let buffer = "";
-    socket.on("data", (chunk) => {
-      buffer += chunk;
-      for (;;) {
-        const newline = buffer.indexOf("\n");
-        if (newline === -1) break;
-        const raw = buffer.slice(0, newline).trim();
-        buffer = buffer.slice(newline + 1);
-        if (!raw) continue;
-        const message = JSON.parse(raw) as { execute?: string };
-        if (!message.execute) continue;
-        seenCommands.push(message.execute);
-        if (message.execute === "stop") {
-          socket.destroy();
-        } else {
-          socket.write(JSON.stringify({ return: {} }) + "\r\n");
-        }
-      }
-    });
-  });
-
-  try {
-    await controller.start();
-    child.emit("spawn");
-
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(qmpSocketPath, () => {
-        server.off("error", reject);
-        resolve();
-      });
-    });
-
-    controller.scheduleIdlePause();
-    await waitFor(() => seenCommands.includes("stop"));
-    await waitFor(() => seenCommands.includes("cont"));
-
-    const closing = controller.close();
-    child.emit("exit", 0, null);
-    await closing;
-  } finally {
-    if (server.listening) {
-      await new Promise<void>((resolve) => server.close(() => resolve()));
-    }
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("SandboxController: stale QMP stop completion is ignored after restart", async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-qmp-test-"));
-  const qmpSocketPath = path.join(tmpDir, "qmp.sock");
-  const children: FakeChildProcess[] = [];
-  const stopSeen = deferred<void>();
-  let stopSocket: net.Socket | null = null;
-
-  mock.method(cp, "spawn", () => {
-    const child = new FakeChildProcess();
-    children.push(child);
-    return child as any;
-  });
-
-  const server = net.createServer((socket) => {
-    socket.setEncoding("utf8");
-    socket.write(
-      JSON.stringify({ QMP: { version: {}, capabilities: [] } }) + "\r\n",
-    );
-
-    let buffer = "";
-    socket.on("data", (chunk) => {
-      buffer += chunk;
-      for (;;) {
-        const newline = buffer.indexOf("\n");
-        if (newline === -1) break;
-        const raw = buffer.slice(0, newline).trim();
-        buffer = buffer.slice(newline + 1);
-        if (!raw) continue;
-        const message = JSON.parse(raw) as { execute?: string };
-        if (message.execute === "stop") {
-          stopSocket = socket;
-          stopSeen.resolve();
-        } else {
-          socket.write(JSON.stringify({ return: {} }) + "\r\n");
-        }
-      }
-    });
-  });
-
-  try {
-    const controller = new SandboxController(
-      makeConfig({ qemuIdlePauseMs: 1, qmpSocketPath }),
-    );
-
-    await controller.start();
-    children[0]!.emit("spawn");
-
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(qmpSocketPath, () => {
-        server.off("error", reject);
-        resolve();
-      });
-    });
-
-    controller.scheduleIdlePause();
-    await stopSeen.promise;
-
-    children[0]!.emit("exit", 0, null);
-    await controller.start();
-    children[1]!.emit("spawn");
-
-    stopSocket!.write(JSON.stringify({ return: {} }) + "\r\n");
-    await waitFor(() => stopSocket?.destroyed === true);
-    await flush();
-
-    assert.equal((controller as any).paused, false);
-    assert.equal((controller as any).qmpIdleDisabled, false);
-
-    const closing = controller.close();
-    children[1]!.emit("exit", 0, null);
-    await closing;
-  } finally {
-    if (server.listening) {
-      await new Promise<void>((resolve) => server.close(() => resolve()));
-    }
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
-
-test("SandboxController: default QMP socket uses virtio socket directory", async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-qmp-dir-"));
-  const child = new FakeChildProcess();
-  let spawnedArgs: string[] = [];
-
-  mock.method(cp, "spawn", (_cmd: string, args: string[]) => {
-    spawnedArgs = args;
-    return child as any;
-  });
-
-  const controller = new SandboxController(
-    makeConfig({
-      qemuIdlePauseMs: 1,
-      virtioSocketPath: path.join(tmpDir, "virtio.sock"),
-    }),
-  );
-
-  try {
-    await controller.start();
-    child.emit("spawn");
-
-    const qmpIndex = spawnedArgs.indexOf("-qmp");
-    assert.notEqual(qmpIndex, -1);
-    const qmpArg = spawnedArgs[qmpIndex + 1]!;
-    const match = /^unix:(.*),server=on,wait=off$/.exec(qmpArg);
-    assert.ok(match);
-    assert.equal(path.dirname(match[1]!), tmpDir);
-
-    const closing = controller.close();
-    child.emit("exit", 0, null);
-    await closing;
-  } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });

--- a/host/test/sandbox-controller.test.ts
+++ b/host/test/sandbox-controller.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import test, { afterEach, mock } from "node:test";
 import { PassThrough } from "node:stream";
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 import * as child_process from "child_process";
 
 import {
@@ -50,6 +54,28 @@ function makeConfig(overrides?: Partial<SandboxConfig>): SandboxConfig {
 
 async function flush(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(predicate(), true);
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 afterEach(() => {
@@ -115,6 +141,265 @@ test("buildQemuArgs: rootDiskVolatileMode=snapshot enables qemu snapshot mode", 
   const driveIndex = args.indexOf("-drive");
   assert.notEqual(driveIndex, -1);
   assert.match(args[driveIndex + 1]!, /snapshot=on/);
+});
+
+test("SandboxController: idle pause uses QMP stop/cont", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-qmp-test-"));
+  const qmpSocketPath = path.join(tmpDir, "qmp.sock");
+  const seenCommands: string[] = [];
+  const child = new FakeChildProcess();
+  let spawnedArgs: string[] = [];
+
+  mock.method(cp, "spawn", (_cmd: string, args: string[]) => {
+    spawnedArgs = args;
+    return child as any;
+  });
+
+  const controller = new SandboxController(
+    makeConfig({ qemuIdlePauseMs: 1, qmpSocketPath }),
+  );
+
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    socket.write(
+      JSON.stringify({ QMP: { version: {}, capabilities: [] } }) + "\r\n",
+    );
+
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      for (;;) {
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) break;
+        const raw = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (!raw) continue;
+        const message = JSON.parse(raw) as { execute?: string };
+        if (message.execute) seenCommands.push(message.execute);
+        socket.write(JSON.stringify({ return: {} }) + "\r\n");
+      }
+    });
+  });
+
+  try {
+    await controller.start();
+    child.emit("spawn");
+
+    assert.ok(spawnedArgs.includes("-qmp"));
+    assert.ok(spawnedArgs.includes(`unix:${qmpSocketPath},server=on,wait=off`));
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(qmpSocketPath, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    controller.scheduleIdlePause();
+    await waitFor(() => seenCommands.includes("stop"));
+
+    await controller.resumeForActivity();
+    await waitFor(() => seenCommands.includes("cont"));
+
+    assert.deepEqual(
+      seenCommands.filter(
+        (command) => command === "stop" || command === "cont",
+      ),
+      ["stop", "cont"],
+    );
+
+    const closing = controller.close();
+    child.emit("exit", 0, null);
+    await closing;
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("SandboxController: failed QMP stop sends best-effort cont", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-qmp-test-"));
+  const qmpSocketPath = path.join(tmpDir, "qmp.sock");
+  const seenCommands: string[] = [];
+  const child = new FakeChildProcess();
+
+  mock.method(cp, "spawn", () => child as any);
+
+  const controller = new SandboxController(
+    makeConfig({ qemuIdlePauseMs: 1, qmpSocketPath }),
+  );
+
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    socket.write(
+      JSON.stringify({ QMP: { version: {}, capabilities: [] } }) + "\r\n",
+    );
+
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      for (;;) {
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) break;
+        const raw = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (!raw) continue;
+        const message = JSON.parse(raw) as { execute?: string };
+        if (!message.execute) continue;
+        seenCommands.push(message.execute);
+        if (message.execute === "stop") {
+          socket.destroy();
+        } else {
+          socket.write(JSON.stringify({ return: {} }) + "\r\n");
+        }
+      }
+    });
+  });
+
+  try {
+    await controller.start();
+    child.emit("spawn");
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(qmpSocketPath, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    controller.scheduleIdlePause();
+    await waitFor(() => seenCommands.includes("stop"));
+    await waitFor(() => seenCommands.includes("cont"));
+
+    const closing = controller.close();
+    child.emit("exit", 0, null);
+    await closing;
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("SandboxController: stale QMP stop completion is ignored after restart", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-qmp-test-"));
+  const qmpSocketPath = path.join(tmpDir, "qmp.sock");
+  const children: FakeChildProcess[] = [];
+  const stopSeen = deferred<void>();
+  let stopSocket: net.Socket | null = null;
+
+  mock.method(cp, "spawn", () => {
+    const child = new FakeChildProcess();
+    children.push(child);
+    return child as any;
+  });
+
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    socket.write(
+      JSON.stringify({ QMP: { version: {}, capabilities: [] } }) + "\r\n",
+    );
+
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      for (;;) {
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) break;
+        const raw = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (!raw) continue;
+        const message = JSON.parse(raw) as { execute?: string };
+        if (message.execute === "stop") {
+          stopSocket = socket;
+          stopSeen.resolve();
+        } else {
+          socket.write(JSON.stringify({ return: {} }) + "\r\n");
+        }
+      }
+    });
+  });
+
+  try {
+    const controller = new SandboxController(
+      makeConfig({ qemuIdlePauseMs: 1, qmpSocketPath }),
+    );
+
+    await controller.start();
+    children[0]!.emit("spawn");
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(qmpSocketPath, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    controller.scheduleIdlePause();
+    await stopSeen.promise;
+
+    children[0]!.emit("exit", 0, null);
+    await controller.start();
+    children[1]!.emit("spawn");
+
+    stopSocket!.write(JSON.stringify({ return: {} }) + "\r\n");
+    await waitFor(() => stopSocket?.destroyed === true);
+    await flush();
+
+    assert.equal((controller as any).paused, false);
+    assert.equal((controller as any).qmpIdleDisabled, false);
+
+    const closing = controller.close();
+    children[1]!.emit("exit", 0, null);
+    await closing;
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("SandboxController: default QMP socket uses virtio socket directory", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-qmp-dir-"));
+  const child = new FakeChildProcess();
+  let spawnedArgs: string[] = [];
+
+  mock.method(cp, "spawn", (_cmd: string, args: string[]) => {
+    spawnedArgs = args;
+    return child as any;
+  });
+
+  const controller = new SandboxController(
+    makeConfig({
+      qemuIdlePauseMs: 1,
+      virtioSocketPath: path.join(tmpDir, "virtio.sock"),
+    }),
+  );
+
+  try {
+    await controller.start();
+    child.emit("spawn");
+
+    const qmpIndex = spawnedArgs.indexOf("-qmp");
+    assert.notEqual(qmpIndex, -1);
+    const qmpArg = spawnedArgs[qmpIndex + 1]!;
+    const match = /^unix:(.*),server=on,wait=off$/.exec(qmpArg);
+    assert.ok(match);
+    assert.equal(path.dirname(match[1]!), tmpDir);
+
+    const closing = controller.close();
+    child.emit("exit", 0, null);
+    await closing;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("SandboxController: start is idempotent while running", async () => {

--- a/host/test/sandbox-server-queueing.test.ts
+++ b/host/test/sandbox-server-queueing.test.ts
@@ -97,6 +97,36 @@ function stdinMessage(id: number, data: Buffer, eof = false) {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function tcpSession(extra: Record<string, unknown> = {}) {
+  return {
+    socket: null,
+    srcIP: "192.168.127.2",
+    srcPort: 12345,
+    dstIP: "198.51.100.1",
+    dstPort: 443,
+    connectIP: "198.51.100.1",
+    connectPort: 443,
+    syntheticHostname: null,
+    mappedTcp: null,
+    flowControlPaused: false,
+    protocol: "tls",
+    connected: false,
+    pendingWrites: [],
+    pendingWriteBytes: 0,
+    ...extra,
+  };
+}
+
 test("exec requests are started concurrently when no file operation is active", () => {
   const server = new SandboxServer(makeResolvedOptions());
   const sent: any[] = [];
@@ -139,6 +169,242 @@ test("maxQueuedExecs caps total running plus queued exec pressure", () => {
     ),
     "expected queue_full once running+queued exec pressure reaches limit",
   );
+});
+
+test("exec admission reserves ids while controller resume is pending", async () => {
+  const server = new SandboxServer(makeResolvedOptions({ maxQueuedExecs: 1 }));
+  const sent: any[] = [];
+  const bridge = (server as any).bridge;
+  bridge.send = (msg: any) => {
+    sent.push(msg);
+    return true;
+  };
+
+  let resume!: () => void;
+  const resumePromise = new Promise<void>((resolve) => {
+    resume = resolve;
+  });
+  (server as any).controller.resumeForActivity = () => resumePromise;
+
+  const a = makeClient();
+  const b = makeClient();
+  const c = makeClient();
+
+  const first = (server as any).handleExec(a.client, execMessage(1));
+  const duplicate = (server as any).handleExec(b.client, execMessage(1));
+  const overLimit = (server as any).handleExec(c.client, execMessage(2));
+
+  assert.ok((server as any).inflight.has(1));
+  assert.equal(sent.length, 0, "exec should not start before resume completes");
+  assert.ok(
+    b.captured.json.some(
+      (m) => m?.type === "error" && m?.id === 1 && m?.code === "duplicate_id",
+    ),
+    "expected duplicate_id while first exec is reserved",
+  );
+  assert.ok(
+    c.captured.json.some(
+      (m) => m?.type === "error" && m?.id === 2 && m?.code === "queue_full",
+    ),
+    "expected pending resume exec to count toward maxQueuedExecs",
+  );
+
+  resume();
+  await Promise.all([first, duplicate, overLimit]);
+
+  assert.equal(sent.filter((m) => m.t === "exec_request").length, 1);
+  assert.ok((server as any).startedExecs.has(1));
+  assert.ok(!(server as any).inflight.has(2));
+});
+
+test("idle pause waits for concurrent VFS requests to finish", async () => {
+  const server = new SandboxServer(makeResolvedOptions());
+  const responses: any[] = [];
+  const pending = [deferred<any>(), deferred<any>()];
+  let scheduleCalls = 0;
+  let cancelCalls = 0;
+
+  (server as any).controller.scheduleIdlePause = () => {
+    scheduleCalls += 1;
+  };
+  (server as any).controller.cancelIdlePause = () => {
+    cancelCalls += 1;
+  };
+  (server as any).fsBridge.send = (msg: any) => {
+    responses.push(msg);
+    return true;
+  };
+  (server as any).fsService = {
+    handleRequest: (message: any) => pending[message.id - 1]!.promise,
+  };
+
+  (server as any).fsBridge.onMessage({
+    v: 1,
+    t: "fs_request",
+    id: 1,
+    p: { op: "stat" },
+  });
+  (server as any).fsBridge.onMessage({
+    v: 1,
+    t: "fs_request",
+    id: 2,
+    p: { op: "stat" },
+  });
+
+  assert.equal(cancelCalls, 2);
+  assert.equal((server as any).activeVfsRequests, 2);
+
+  pending[0]!.resolve({ v: 1, t: "fs_response", id: 1, p: { op: "stat" } });
+  await pending[0]!.promise;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(responses.length, 1);
+  assert.equal((server as any).activeVfsRequests, 1);
+  assert.equal(scheduleCalls, 0);
+
+  pending[1]!.resolve({ v: 1, t: "fs_response", id: 2, p: { op: "stat" } });
+  await pending[1]!.promise;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(responses.length, 2);
+  assert.equal((server as any).activeVfsRequests, 0);
+  assert.equal(scheduleCalls, 1);
+});
+
+test("fs_request waits for controller resume before handling VFS request", async () => {
+  const server = new SandboxServer(makeResolvedOptions());
+  const resume = deferred<void>();
+  const responses: any[] = [];
+  let handled = false;
+  let scheduleCalls = 0;
+
+  (server as any).controller.resumeForActivity = () => resume.promise;
+  (server as any).controller.scheduleIdlePause = () => {
+    scheduleCalls += 1;
+  };
+  (server as any).fsBridge.send = (msg: any) => {
+    responses.push(msg);
+    return true;
+  };
+  (server as any).fsService = {
+    handleRequest: async (message: any) => {
+      handled = true;
+      return { v: 1, t: "fs_response", id: message.id, p: { op: "stat" } };
+    },
+  };
+
+  (server as any).fsBridge.onMessage({
+    v: 1,
+    t: "fs_request",
+    id: 1,
+    p: { op: "stat" },
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal((server as any).activeVfsRequests, 1);
+  assert.equal(handled, false);
+  assert.equal(responses.length, 0);
+
+  resume.resolve();
+  await resume.promise;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(handled, true);
+  assert.equal(responses.length, 1);
+  assert.equal((server as any).activeVfsRequests, 0);
+  assert.equal(scheduleCalls, 1);
+});
+
+test("network tcp sessions count as active guest activity", () => {
+  const server = new SandboxServer(makeResolvedOptions({ netEnabled: true }));
+  const network = (server as any).network;
+  let resumeCalls = 0;
+  let scheduleCalls = 0;
+
+  (server as any).controller.resumeForActivity = () => {
+    resumeCalls += 1;
+  };
+  (server as any).controller.scheduleIdlePause = () => {
+    scheduleCalls += 1;
+  };
+
+  network.tcpSessions.set("flow", tcpSession());
+
+  assert.equal(resumeCalls, 1);
+  assert.equal((server as any).hasActiveGuestActivity(), true);
+
+  (server as any).scheduleControllerIdlePause();
+  assert.equal(scheduleCalls, 0);
+
+  network.tcpSessions.delete("flow");
+
+  assert.equal((server as any).hasActiveGuestActivity(), false);
+  assert.equal(scheduleCalls, 1);
+});
+
+test("network resume re-arms idle after a short-lived tcp session", async () => {
+  const server = new SandboxServer(makeResolvedOptions({ netEnabled: true }));
+  const network = (server as any).network;
+  const controller = (server as any).controller;
+  const resume = deferred<void>();
+  let scheduleCalls = 0;
+
+  controller.pauseInProgress = true;
+  controller.resumeForActivity = () =>
+    resume.promise.finally(() => {
+      controller.pauseInProgress = false;
+    });
+  controller.scheduleIdlePause = () => {
+    if (!controller.pauseInProgress) scheduleCalls += 1;
+  };
+
+  network.tcpSessions.set("flow", tcpSession());
+  network.tcpSessions.delete("flow");
+  assert.equal(scheduleCalls, 0);
+
+  resume.resolve();
+  await resume.promise;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(scheduleCalls, 1);
+});
+
+test("sendControlMessage aborts after waiting for resume", async () => {
+  const server = new SandboxServer(makeResolvedOptions());
+  const resume = deferred<void>();
+  const ac = new AbortController();
+  let sendCalls = 0;
+
+  (server as any).controller.resumeForActivity = () => resume.promise;
+  (server as any).bridge.send = () => {
+    sendCalls += 1;
+    return true;
+  };
+
+  const sending = (server as any).sendControlMessage({ v: 1 }, ac.signal);
+  ac.abort();
+  resume.resolve();
+
+  await assert.rejects(sending, /operation aborted/);
+  assert.equal(sendCalls, 0);
+});
+
+test("idle pause is armed when sandbox reaches running with no active work", () => {
+  const server = new SandboxServer(makeResolvedOptions());
+  let scheduleCalls = 0;
+
+  (server as any).bridge.connect = () => {};
+  (server as any).fsBridge.connect = () => {};
+  (server as any).sshBridge.connect = () => {};
+  (server as any).ingressBridge.connect = () => {};
+  (server as any).controller.scheduleIdlePause = () => {
+    scheduleCalls += 1;
+  };
+
+  (server as any).controller.emit("state", "running");
+
+  assert.equal((server as any).status, "running");
+  assert.equal(scheduleCalls, 1);
 });
 
 test("started exec stdin replay keeps data buffered on queue pressure and retries", () => {

--- a/host/test/sandbox-server-queueing.test.ts
+++ b/host/test/sandbox-server-queueing.test.ts
@@ -217,132 +217,7 @@ test("exec admission reserves ids while controller resume is pending", async () 
   assert.ok(!(server as any).inflight.has(2));
 });
 
-test("idle pause waits for concurrent VFS requests to finish", async () => {
-  const server = new SandboxServer(makeResolvedOptions());
-  const responses: any[] = [];
-  const pending = [deferred<any>(), deferred<any>()];
-  let scheduleCalls = 0;
-  let cancelCalls = 0;
-
-  (server as any).controller.scheduleIdlePause = () => {
-    scheduleCalls += 1;
-  };
-  (server as any).controller.cancelIdlePause = () => {
-    cancelCalls += 1;
-  };
-  (server as any).fsBridge.send = (msg: any) => {
-    responses.push(msg);
-    return true;
-  };
-  (server as any).fsService = {
-    handleRequest: (message: any) => pending[message.id - 1]!.promise,
-  };
-
-  (server as any).fsBridge.onMessage({
-    v: 1,
-    t: "fs_request",
-    id: 1,
-    p: { op: "stat" },
-  });
-  (server as any).fsBridge.onMessage({
-    v: 1,
-    t: "fs_request",
-    id: 2,
-    p: { op: "stat" },
-  });
-
-  assert.equal(cancelCalls, 2);
-  assert.equal((server as any).activeVfsRequests, 2);
-
-  pending[0]!.resolve({ v: 1, t: "fs_response", id: 1, p: { op: "stat" } });
-  await pending[0]!.promise;
-  await new Promise<void>((resolve) => setImmediate(resolve));
-
-  assert.equal(responses.length, 1);
-  assert.equal((server as any).activeVfsRequests, 1);
-  assert.equal(scheduleCalls, 0);
-
-  pending[1]!.resolve({ v: 1, t: "fs_response", id: 2, p: { op: "stat" } });
-  await pending[1]!.promise;
-  await new Promise<void>((resolve) => setImmediate(resolve));
-
-  assert.equal(responses.length, 2);
-  assert.equal((server as any).activeVfsRequests, 0);
-  assert.equal(scheduleCalls, 1);
-});
-
-test("fs_request waits for controller resume before handling VFS request", async () => {
-  const server = new SandboxServer(makeResolvedOptions());
-  const resume = deferred<void>();
-  const responses: any[] = [];
-  let handled = false;
-  let scheduleCalls = 0;
-
-  (server as any).controller.resumeForActivity = () => resume.promise;
-  (server as any).controller.scheduleIdlePause = () => {
-    scheduleCalls += 1;
-  };
-  (server as any).fsBridge.send = (msg: any) => {
-    responses.push(msg);
-    return true;
-  };
-  (server as any).fsService = {
-    handleRequest: async (message: any) => {
-      handled = true;
-      return { v: 1, t: "fs_response", id: message.id, p: { op: "stat" } };
-    },
-  };
-
-  (server as any).fsBridge.onMessage({
-    v: 1,
-    t: "fs_request",
-    id: 1,
-    p: { op: "stat" },
-  });
-  await new Promise<void>((resolve) => setImmediate(resolve));
-
-  assert.equal((server as any).activeVfsRequests, 1);
-  assert.equal(handled, false);
-  assert.equal(responses.length, 0);
-
-  resume.resolve();
-  await resume.promise;
-  await new Promise<void>((resolve) => setImmediate(resolve));
-
-  assert.equal(handled, true);
-  assert.equal(responses.length, 1);
-  assert.equal((server as any).activeVfsRequests, 0);
-  assert.equal(scheduleCalls, 1);
-});
-
-test("network tcp sessions count as active guest activity", () => {
-  const server = new SandboxServer(makeResolvedOptions({ netEnabled: true }));
-  const network = (server as any).network;
-  let resumeCalls = 0;
-  let scheduleCalls = 0;
-
-  (server as any).controller.resumeForActivity = () => {
-    resumeCalls += 1;
-  };
-  (server as any).controller.scheduleIdlePause = () => {
-    scheduleCalls += 1;
-  };
-
-  network.tcpSessions.set("flow", tcpSession());
-
-  assert.equal(resumeCalls, 1);
-  assert.equal((server as any).hasActiveGuestActivity(), true);
-
-  (server as any).scheduleControllerIdlePause();
-  assert.equal(scheduleCalls, 0);
-
-  network.tcpSessions.delete("flow");
-
-  assert.equal((server as any).hasActiveGuestActivity(), false);
-  assert.equal(scheduleCalls, 1);
-});
-
-test("network resume re-arms idle after a short-lived tcp session", async () => {
+test("network activity blocks idle until resume settles", async () => {
   const server = new SandboxServer(makeResolvedOptions({ netEnabled: true }));
   const network = (server as any).network;
   const controller = (server as any).controller;
@@ -359,9 +234,11 @@ test("network resume re-arms idle after a short-lived tcp session", async () => 
   };
 
   network.tcpSessions.set("flow", tcpSession());
-  network.tcpSessions.delete("flow");
+  assert.equal((server as any).hasActiveGuestActivity(), true);
+  (server as any).scheduleControllerIdlePause();
   assert.equal(scheduleCalls, 0);
 
+  network.tcpSessions.delete("flow");
   resume.resolve();
   await resume.promise;
   await new Promise<void>((resolve) => setImmediate(resolve));


### PR DESCRIPTION
This PR adds conservative QEMU auto-pause support for idle sandboxes. On macOS/HVF, QEMU VMs now default to pausing after 30s of inactivity via QMP, with a configurable `qemuIdlePauseMs` option to tune or disable the behavior. The controller creates a short QMP socket path, issues `stop`/`cont`, cleans up sockets, and disables idle pause if QMP becomes unreliable.

The sandbox server now tracks guest activity across execs, queued work, VFS requests, SSH/ingress TCP streams, and network sessions so VMs are only paused when truly idle. Any new activity resumes the VM before proceeding, including exec admission and filesystem handling, while tests cover QMP pause/resume wiring, exec queue accounting during pending resumes, and network activity preventing premature pause.

Fixes #109 