### PR TITLE
Add VM.getHostResourceStats()

### DIFF
--- a/host/src/host/resource-stats.ts
+++ b/host/src/host/resource-stats.ts
@@ -1,0 +1,154 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+
+export type VMHostResourceStats = {
+  /** Host PID of the primary VM runner process */
+  pid: number | null;
+  /** RSS of the primary runner process in `bytes` */
+  rssBytes: number | null;
+  /** RSS of the primary runner process plus known descendants in `bytes` */
+  treeRssBytes: number | null;
+};
+
+export function getHostResourceStatsForPid(
+  pid: number | null,
+): VMHostResourceStats {
+  if (pid === null) {
+    return { pid: null, rssBytes: null, treeRssBytes: null };
+  }
+
+  return {
+    pid,
+    rssBytes: readProcessRssBytes(pid),
+    treeRssBytes: readProcessTreeRssBytes(pid),
+  };
+}
+
+export function readProcessRssBytes(pid: number): number | null {
+  if (!isValidPid(pid)) return null;
+  if (process.platform === "linux") return readProcStatusRssBytes(pid);
+  return readPsRssBytes(pid);
+}
+
+export function readProcessTreeRssBytes(pid: number): number | null {
+  if (!isValidPid(pid)) return null;
+  if (process.platform !== "linux") return null;
+
+  const descendants = getLinuxDescendantPids(pid);
+  if (descendants === null) return null;
+
+  let total = 0;
+  let found = false;
+  for (const descendantPid of descendants) {
+    const rssBytes = readProcStatusRssBytes(descendantPid);
+    if (rssBytes === null) continue;
+    total += rssBytes;
+    found = true;
+  }
+
+  return found ? total : null;
+}
+
+function isValidPid(pid: number): boolean {
+  return Number.isInteger(pid) && pid > 0;
+}
+
+function readProcStatusRssBytes(pid: number): number | null {
+  try {
+    const status = fs.readFileSync(`/proc/${pid}/status`, "utf8");
+    const match = /^VmRSS:\s+(\d+)\s+kB$/m.exec(status);
+    if (!match) return null;
+    const kib = Number(match[1]);
+    if (!Number.isSafeInteger(kib) || kib < 0) return null;
+    return kib * 1024;
+  } catch {
+    return null;
+  }
+}
+
+function readPsRssBytes(pid: number): number | null {
+  try {
+    const stdout = execFileSync("ps", ["-o", "rss=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const trimmed = stdout.trim();
+    if (!/^\d+$/.test(trimmed)) return null;
+    const kib = Number(trimmed);
+    if (!Number.isSafeInteger(kib) || kib < 0) return null;
+    return kib * 1024;
+  } catch {
+    return null;
+  }
+}
+
+function getLinuxDescendantPids(rootPid: number): number[] | null {
+  const parentByPid = readProcParentMap();
+  if (parentByPid === null) return null;
+
+  const childrenByParent = new Map<number, number[]>();
+  for (const [pid, parentPid] of parentByPid.entries()) {
+    const children = childrenByParent.get(parentPid);
+    if (children) {
+      children.push(pid);
+    } else {
+      childrenByParent.set(parentPid, [pid]);
+    }
+  }
+
+  const result: number[] = [];
+  const seen = new Set<number>();
+  const stack = [rootPid];
+
+  while (stack.length > 0) {
+    const pid = stack.pop()!;
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    result.push(pid);
+
+    for (const childPid of childrenByParent.get(pid) ?? []) {
+      stack.push(childPid);
+    }
+  }
+
+  return result;
+}
+
+function readProcParentMap(): Map<number, number> | null {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync("/proc");
+  } catch {
+    return null;
+  }
+
+  const parentByPid = new Map<number, number>();
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number(entry);
+    if (!isValidPid(pid)) continue;
+
+    const parentPid = readProcStatParentPid(pid);
+    if (parentPid === null) continue;
+    parentByPid.set(pid, parentPid);
+  }
+
+  return parentByPid;
+}
+
+function readProcStatParentPid(pid: number): number | null {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    const commandEnd = stat.lastIndexOf(")");
+    if (commandEnd === -1) return null;
+
+    const fields = stat.slice(commandEnd + 1).trim().split(/\s+/);
+    if (fields.length < 2) return null;
+
+    const parentPid = Number(fields[1]);
+    if (!Number.isInteger(parentPid) || parentPid < 0) return null;
+    return parentPid;
+  } catch {
+    return null;
+  }
+}

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -10,6 +10,7 @@ export {
   VM,
   type VMOptions,
   type VMState,
+  type VMHostResourceStats,
   type EnableSshOptions,
   type SshAccess,
   type VmFs,

--- a/host/src/sandbox/controller.ts
+++ b/host/src/sandbox/controller.ts
@@ -110,6 +110,10 @@ export class SandboxController extends EventEmitter {
     return this.state;
   }
 
+  getHostPid(): number | null {
+    return this.child?.pid ?? null;
+  }
+
   async start() {
     if (this.child) return;
 

--- a/host/src/sandbox/krun-controller.ts
+++ b/host/src/sandbox/krun-controller.ts
@@ -164,6 +164,10 @@ export class KrunController extends EventEmitter {
     return this.state;
   }
 
+  getHostPid(): number | null {
+    return this.child?.pid ?? null;
+  }
+
   async start() {
     if (this.child) return;
 

--- a/host/src/sandbox/server.ts
+++ b/host/src/sandbox/server.ts
@@ -108,6 +108,7 @@ type BridgeWritableWaiter = {
 type SandboxControllerLike = {
   setAppend(append: string): void;
   getState(): SandboxState;
+  getHostPid(): number | null;
   start(): Promise<void>;
   close(): Promise<void>;
   restart(): Promise<void>;
@@ -292,6 +293,11 @@ export class SandboxServer extends EventEmitter {
   /** @internal resolved VM backend name */
   getVmmBackend(): "qemu" | "krun" {
     return this.options.vmm;
+  }
+
+  /** @internal host PID of the active VM runner process */
+  getHostPid(): number | null {
+    return this.controller.getHostPid();
   }
 
   /** @internal resolved VM backend binary path */

--- a/host/src/vm/core.ts
+++ b/host/src/vm/core.ts
@@ -19,6 +19,10 @@ import {
   resolveQcow2BackingPath,
 } from "../qemu/img.ts";
 import {
+  getHostResourceStatsForPid,
+  type VMHostResourceStats,
+} from "../host/resource-stats.ts";
+import {
   VmCheckpoint,
   registerVmCreate,
   type VmCheckpointData,
@@ -201,6 +205,8 @@ export type SshAccess = {
   /** close the local forwarder and remove temporary key material */
   close(): Promise<void>;
 };
+
+export type { VMHostResourceStats } from "../host/resource-stats.ts";
 
 export type VMState = SandboxState | "unknown";
 
@@ -593,6 +599,14 @@ export class VM {
    */
   async close() {
     return this.closeSingleflight.run(() => this.closeInternal());
+  }
+
+  /**
+   * Return host-side resource usage for the active VM runner process.
+   */
+  async getHostResourceStats(): Promise<VMHostResourceStats> {
+    const pid = this.server?.getHostPid() ?? null;
+    return getHostResourceStatsForPid(pid);
   }
 
   /**

--- a/host/test/host-resource-stats.test.ts
+++ b/host/test/host-resource-stats.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getHostResourceStatsForPid,
+  readProcessRssBytes,
+  readProcessTreeRssBytes,
+} from "../src/host/resource-stats.ts";
+
+test("host resource stats: null pid returns null fields", () => {
+  assert.deepEqual(getHostResourceStatsForPid(null), {
+    pid: null,
+    rssBytes: null,
+    treeRssBytes: null,
+  });
+});
+
+test("host resource stats: reports current process RSS", () => {
+  const rssBytes = readProcessRssBytes(process.pid);
+
+  assert.ok(rssBytes !== null);
+  assert.ok(rssBytes > 0);
+});
+
+test("host resource stats: reports Linux process tree RSS", { skip: process.platform !== "linux" }, () => {
+  const rssBytes = readProcessRssBytes(process.pid);
+  const treeRssBytes = readProcessTreeRssBytes(process.pid);
+
+  assert.ok(rssBytes !== null);
+  assert.ok(treeRssBytes !== null);
+  assert.ok(treeRssBytes >= rssBytes);
+});

--- a/host/test/vm-internals.test.ts
+++ b/host/test/vm-internals.test.ts
@@ -124,6 +124,21 @@ test("vm internals: VM.create validates rootfs size before asset resolution", as
   );
 });
 
+test("vm internals: stopped VM host resource stats are null", async () => {
+  const { vm, cleanup } = makeVm({ autoStart: false, vfs: null });
+
+  try {
+    assert.deepEqual(await vm.getHostResourceStats(), {
+      pid: null,
+      rssBytes: null,
+      treeRssBytes: null,
+    });
+  } finally {
+    await vm.close();
+    cleanup();
+  }
+});
+
 test("vm internals: rootfs readonly mode sets readonly root disk", async () => {
   const { vm, cleanup } = makeVm({
     autoStart: false,


### PR DESCRIPTION
Expose the active VM runner PID from both qemu and krun controllers through SandboxServer, then add VM.getHostResourceStats() returning pid, rssBytes, and treeRssBytes with nulls for unavailable data.

Implement host RSS sampling in host/resource-stats.ts: Linux reads /proc/<pid>/status, Linux tree RSS walks /proc/*/stat by PPID, and non-Linux uses ps as a best-effort primary RSS fallback.

Export VMHostResourceStats and add coverage for stopped VMs and direct host resource stat helpers.