### PR TITLE
feat(vm): add VM.getHostPid()

### DIFF
--- a/docs/sdk-vm.md
+++ b/docs/sdk-vm.md
@@ -44,6 +44,13 @@ Advanced users can access the registry/attach helpers directly:
 - `gcSessions()`
 - `connectToSession()`
 
+## Host Runner PID
+
+`vm.getHostPid()` returns the host PID of the active VM runner process, or
+`null` before the VM has started / after it has stopped. Callers can use this to
+sample host-side process metrics such as disk or memory usage with their own
+platform-specific tooling.
+
 ## `vm.exec()`
 
 This is the most common operation. It returns an `ExecProcess` (a running

--- a/docs/sdk-vm.md
+++ b/docs/sdk-vm.md
@@ -46,10 +46,17 @@ Advanced users can access the registry/attach helpers directly:
 
 ## Host Runner PID
 
-`vm.getHostPid()` returns the host PID of the active VM runner process, or
-`null` before the VM has started / after it has stopped. Callers can use this to
-sample host-side process metrics such as disk or memory usage with their own
-platform-specific tooling.
+`vm.getHostPid()` returns the host PID of the active VM runner process. Callers
+can use this to sample host-side process metrics such as disk or memory usage
+with their own platform-specific tooling.
+
+The return value is `null` when there is no active runner process to report,
+including:
+
+- before the VM has started, such as with `VM.create({ autoStart: false })`
+- after the VM has been closed or the runner process has exited
+- while `vm.close()` is in progress, after Gondolin has released its runner handle
+- if a backend fails before spawning its runner, or a future backend does not expose a PID
 
 ## `vm.exec()`
 

--- a/host/src/sandbox/controller.ts
+++ b/host/src/sandbox/controller.ts
@@ -325,6 +325,10 @@ export class SandboxController extends EventEmitter {
     return this.state;
   }
 
+  getHostPid(): number | null {
+    return this.child?.pid ?? null;
+  }
+
   async start() {
     if (this.child) return;
 

--- a/host/src/sandbox/krun-controller.ts
+++ b/host/src/sandbox/krun-controller.ts
@@ -164,6 +164,10 @@ export class KrunController extends EventEmitter {
     return this.state;
   }
 
+  getHostPid(): number | null {
+    return this.child?.pid ?? null;
+  }
+
   async start() {
     if (this.child) return;
 

--- a/host/src/sandbox/server-ops.ts
+++ b/host/src/sandbox/server-ops.ts
@@ -72,6 +72,13 @@ export class SandboxServerOps {
     return this.status;
   }
 
+  /**
+   * Return the host PID of the active VM runner process, if available.
+   */
+  getHostPid(): number | null {
+    return this.controller.getHostPid?.() ?? null;
+  }
+
   getVfsProvider() {
     return this.vfsProvider;
   }

--- a/host/src/sandbox/server.ts
+++ b/host/src/sandbox/server.ts
@@ -108,6 +108,7 @@ type BridgeWritableWaiter = {
 type SandboxControllerLike = {
   setAppend(append: string): void;
   getState(): SandboxState;
+  getHostPid(): number | null;
   start(): Promise<void>;
   close(): Promise<void>;
   restart(): Promise<void>;

--- a/host/src/vm/core.ts
+++ b/host/src/vm/core.ts
@@ -596,7 +596,7 @@ export class VM {
   }
 
   /**
-   * Return the host PID of the active VM runner process, if available.
+   * Return the host PID of the active VM runner process, or null when no runner is active.
    */
   getHostPid(): number | null {
     return this.server?.getHostPid() ?? null;

--- a/host/src/vm/core.ts
+++ b/host/src/vm/core.ts
@@ -596,6 +596,13 @@ export class VM {
   }
 
   /**
+   * Return the host PID of the active VM runner process, if available.
+   */
+  getHostPid(): number | null {
+    return this.server?.getHostPid() ?? null;
+  }
+
+  /**
    * Execute a command in the sandbox.
    *
    * Returns an ExecProcess which can be:

--- a/host/test/host-pid-stats.test.ts
+++ b/host/test/host-pid-stats.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import { VM } from "../src/vm/core.ts";
+import { scheduleForceExit, shouldSkipVmTests } from "./helpers/vm-fixture.ts";
+
+const skipVmTests = shouldSkipVmTests();
+const timeoutMs = Number(process.env.WS_TIMEOUT ?? 60000);
+const startTimeoutMs = Math.max(
+  1,
+  Number(process.env.GONDOLIN_HOST_PID_START_TIMEOUT_MS ?? 30000),
+);
+
+function readPsStats(pid: number): string {
+  return execFileSync(
+    "ps",
+    ["-o", "pid,ppid,rss,vsz,pcpu,pmem,etime,command", "-p", String(pid)],
+    { encoding: "utf8" },
+  );
+}
+
+test.after(() => {
+  scheduleForceExit();
+});
+
+test(
+  "VM.getHostPid exposes a pid that can be sampled with ps",
+  { skip: skipVmTests, timeout: timeoutMs },
+  async () => {
+    const vm = await VM.create({
+      startTimeoutMs,
+      sandbox: { console: "none" },
+    });
+
+    try {
+      await vm.start();
+
+      const pid = vm.getHostPid();
+      assert.equal(typeof pid, "number");
+      assert.ok(pid > 0, "expected a positive host pid");
+
+      const stats = readPsStats(pid);
+      console.log(`ps stats for VM host pid ${pid}:\n${stats}`);
+
+      assert.match(stats, /^\s*PID\s+PPID\s+RSS\s+VSZ\s+%CPU\s+%MEM\s+ELAPSED\s+COMMAND/m);
+      assert.match(stats, new RegExp(`\\b${pid}\\b`));
+    } finally {
+      await vm.close();
+    }
+  },
+);

--- a/host/test/sandbox-controller.test.ts
+++ b/host/test/sandbox-controller.test.ts
@@ -21,6 +21,7 @@ import {
 const cp: any = (child_process as any).default ?? (child_process as any);
 
 class FakeChildProcess extends EventEmitter {
+  pid = 12345;
   stdout = new PassThrough();
   stderr = new PassThrough();
   killedSignals: Array<string | undefined> = [];
@@ -117,6 +118,21 @@ test("SandboxController: start emits state transitions and forwards logs", async
 
   assert.equal(exits.length, 1);
   assert.deepEqual(exits[0], { code: 0, signal: null });
+});
+
+test("SandboxController: getHostPid reflects the active child process", async () => {
+  const child = new FakeChildProcess();
+  child.pid = 23456;
+  mock.method(cp, "spawn", () => child as any);
+
+  const controller = new SandboxController(makeConfig());
+  assert.equal(controller.getHostPid(), null);
+
+  await controller.start();
+  assert.equal(controller.getHostPid(), 23456);
+
+  child.emit("exit", 0, null);
+  assert.equal(controller.getHostPid(), null);
 });
 
 test("buildQemuArgs: rootDiskVolatileMode=snapshot enables qemu snapshot mode", () => {

--- a/host/test/vm-internals.test.ts
+++ b/host/test/vm-internals.test.ts
@@ -124,6 +124,20 @@ test("vm internals: VM.create validates rootfs size before asset resolution", as
   );
 });
 
+test("vm internals: getHostPid returns null before start", () => {
+  const { vm, cleanup } = makeVm({
+    autoStart: false,
+    vfs: null,
+    rootfs: { mode: "readonly" },
+  });
+
+  try {
+    assert.equal(vm.getHostPid(), null);
+  } finally {
+    cleanup();
+  }
+});
+
 test("vm internals: rootfs readonly mode sets readonly root disk", async () => {
   const { vm, cleanup } = makeVm({
     autoStart: false,


### PR DESCRIPTION
Allows callers to collect their own host-side process metrics.