### PR TITLE
feat: trufflehog for host suggestions

### DIFF
--- a/builtin-trufflehog-registry.json
+++ b/builtin-trufflehog-registry.json
@@ -1,0 +1,41 @@
+{
+  "schema": 1,
+  "refs": {
+    "trufflehog:3.95.3": {
+      "darwin-arm64": "trufflehog-3.95.3-darwin-arm64",
+      "darwin-x64": "trufflehog-3.95.3-darwin-x64",
+      "linux-arm64": "trufflehog-3.95.3-linux-arm64",
+      "linux-x64": "trufflehog-3.95.3-linux-x64"
+    }
+  },
+  "builds": {
+    "trufflehog-3.95.3-darwin-arm64": {
+      "version": "3.95.3",
+      "platform": "darwin-arm64",
+      "url": "https://github.com/trufflesecurity/trufflehog/releases/download/v3.95.3/trufflehog_3.95.3_darwin_arm64.tar.gz",
+      "sha256": "17da7aa3412bb7f6220728a6e908480e734a69ea53c029a3153859f9fa1a22c8",
+      "sourceUrl": "https://codeload.github.com/trufflesecurity/trufflehog/tar.gz/refs/tags/v3.95.3"
+    },
+    "trufflehog-3.95.3-darwin-x64": {
+      "version": "3.95.3",
+      "platform": "darwin-x64",
+      "url": "https://github.com/trufflesecurity/trufflehog/releases/download/v3.95.3/trufflehog_3.95.3_darwin_amd64.tar.gz",
+      "sha256": "dc2a74d3cfdac2738aa83f7342a958b002e0dff99abbac460dffe6bacc4939a5",
+      "sourceUrl": "https://codeload.github.com/trufflesecurity/trufflehog/tar.gz/refs/tags/v3.95.3"
+    },
+    "trufflehog-3.95.3-linux-arm64": {
+      "version": "3.95.3",
+      "platform": "linux-arm64",
+      "url": "https://github.com/trufflesecurity/trufflehog/releases/download/v3.95.3/trufflehog_3.95.3_linux_arm64.tar.gz",
+      "sha256": "8e205da06172db049129101d475dc4f7f43904d315384e4e32b9c5009cac27c8",
+      "sourceUrl": "https://codeload.github.com/trufflesecurity/trufflehog/tar.gz/refs/tags/v3.95.3"
+    },
+    "trufflehog-3.95.3-linux-x64": {
+      "version": "3.95.3",
+      "platform": "linux-x64",
+      "url": "https://github.com/trufflesecurity/trufflehog/releases/download/v3.95.3/trufflehog_3.95.3_linux_amd64.tar.gz",
+      "sha256": "5d836eae522540a32ca0f1a1e00efd4c3153a52462466a4b4008fac1e6c1a548",
+      "sourceUrl": "https://codeload.github.com/trufflesecurity/trufflehog/tar.gz/refs/tags/v3.95.3"
+    }
+  }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,6 +88,12 @@ without exposing them inside the VM (for HTTP/TLS-mediated flows).
     - May be repeated
     - `HOST_PATTERN` supports `*` wildcards (for example `*.github.com`)
 
+- `--host-secret NAME[=VALUE]`
+    - Make a secret available inside the VM as an environment variable named `NAME`
+    - Gondolin resolves a managed `trufflehog` helper on first use, then scans the current repo for suggested hostnames and asks you to confirm them
+    - If no suggestions are found, the command fails and asks you to re-run with explicit hosts
+    - If `=VALUE` is omitted, the value is read from the host environment variable `$NAME`
+
 - `--host-secret NAME@HOST[,HOST...][=VALUE]`
     - Make a secret available inside the VM as an environment variable named `NAME`
     - The VM only sees a random placeholder value; the host replaces that
@@ -508,6 +514,27 @@ Image selectors accepted by `--image` and `sandbox.imagePath` strings:
 - `GONDOLIN_CHECKPOINT_DIR`
     - Override checkpoint directory used by `gondolin snapshot` / `gondolin bash --resume`
     - Default: `~/.cache/gondolin/checkpoints`
+
+- `GONDOLIN_TRUFFLEHOG_PATH`
+    - Override the `trufflehog` helper binary path used for host suggestion discovery
+
+- `GONDOLIN_TRUFFLEHOG_DIR`
+    - Override the directory containing a managed `trufflehog` binary
+
+- `GONDOLIN_TRUFFLEHOG_REGISTRY_URL`
+    - Override builtin trufflehog registry JSON URL
+
+- `GONDOLIN_TRUFFLEHOG_STORE`
+    - Override local store for the managed `trufflehog` helper
+    - Default: `~/.cache/gondolin/tools/trufflehog`
+
+You can inspect the helper with:
+
+```bash
+gondolin tools trufflehog
+gondolin tools trufflehog --install
+gondolin tools trufflehog --json
+```
 
 - `GONDOLIN_SESSIONS_DIR`
     - Override session registry directory used by `gondolin list` / `gondolin attach`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,7 +90,7 @@ without exposing them inside the VM (for HTTP/TLS-mediated flows).
 
 - `--host-secret NAME[=VALUE]`
     - Make a secret available inside the VM as an environment variable named `NAME`
-    - Gondolin resolves a managed `trufflehog` helper on first use, then scans the current repo for suggested hostnames and asks you to confirm them
+    - Gondolin resolves a managed `trufflehog` helper on first use, then scans for suggested hostnames and asks you to confirm them
     - If no suggestions are found, the command fails and asks you to re-run with explicit hosts
     - If `=VALUE` is omitted, the value is read from the host environment variable `$NAME`
 
@@ -515,20 +515,7 @@ Image selectors accepted by `--image` and `sandbox.imagePath` strings:
     - Override checkpoint directory used by `gondolin snapshot` / `gondolin bash --resume`
     - Default: `~/.cache/gondolin/checkpoints`
 
-- `GONDOLIN_TRUFFLEHOG_PATH`
-    - Override the `trufflehog` helper binary path used for host suggestion discovery
-
-- `GONDOLIN_TRUFFLEHOG_DIR`
-    - Override the directory containing a managed `trufflehog` binary
-
-- `GONDOLIN_TRUFFLEHOG_REGISTRY_URL`
-    - Override builtin trufflehog registry JSON URL
-
-- `GONDOLIN_TRUFFLEHOG_STORE`
-    - Override local store for the managed `trufflehog` helper
-    - Default: `~/.cache/gondolin/tools/trufflehog`
-
-You can inspect the helper with:
+You can inspect the managed `trufflehog` helper with:
 
 ```bash
 gondolin tools trufflehog

--- a/host/bin/gondolin.ts
+++ b/host/bin/gondolin.ts
@@ -2820,18 +2820,7 @@ async function runTools(argv: string[]) {
       }
 
       const status = await getTrufflehogStatus();
-      const resolvedPath =
-        status.configuredPath ??
-        (status.configuredDir
-          ? path.join(status.configuredDir, "trufflehog")
-          : status.managedPath);
-      const source = status.configuredPath
-        ? "configured-path"
-        : status.configuredDir
-          ? "configured-dir"
-          : status.installed
-            ? "managed"
-            : "downloadable";
+      const source = status.installed ? "managed" : "downloadable";
 
       if (asJson) {
         console.log(
@@ -2842,10 +2831,8 @@ async function runTools(argv: string[]) {
               platform: status.platform,
               source,
               installed: status.installed,
-              configuredPath: status.configuredPath,
-              configuredDir: status.configuredDir,
               managedPath: status.managedPath,
-              resolvedPath,
+              resolvedPath: status.managedPath,
               downloadUrl: status.downloadUrl,
               ref: status.ref,
               buildId: status.buildId,
@@ -2864,14 +2851,9 @@ async function runTools(argv: string[]) {
       console.log(`platform: ${status.platform}`);
       console.log(`source: ${source}`);
       console.log(`installed: ${status.installed ? "yes" : "no"}`);
-      console.log(`resolved path: ${resolvedPath}`);
-      if (status.configuredDir) {
-        console.log(`configured dir: ${status.configuredDir}`);
-      }
-      if (!status.configuredPath && !status.configuredDir) {
-        console.log(`managed path: ${status.managedPath}`);
-        console.log(`download url: ${status.downloadUrl}`);
-      }
+      console.log(`resolved path: ${status.managedPath}`);
+      console.log(`managed path: ${status.managedPath}`);
+      console.log(`download url: ${status.downloadUrl}`);
       return;
     }
     default:

--- a/host/bin/gondolin.ts
+++ b/host/bin/gondolin.ts
@@ -716,9 +716,7 @@ async function resolveSecretHosts(secrets: SecretSpec[]): Promise<SecretSpec[]> 
       `Discovering suggested hosts for secret ${secret.name} with trufflehog...\n`,
     );
     const suggestions = await suggestHostsForSecret({
-      secretName: secret.name,
       secretValue: secret.value,
-      cwd: process.cwd(),
     });
 
     if (suggestions.length === 0) {

--- a/host/bin/gondolin.ts
+++ b/host/bin/gondolin.ts
@@ -9,6 +9,7 @@ import { PassThrough } from "stream";
 import { fileURLToPath } from "url";
 
 import { VmCheckpoint } from "../src/checkpoint.ts";
+import { gondolinCacheDir } from "../src/cache.ts";
 import { parseDiskSizeToBytes } from "../src/qemu/img.ts";
 import { VM } from "../src/vm/core.ts";
 import type { VirtualProvider } from "../src/vfs/node/index.ts";
@@ -79,11 +80,9 @@ function getDefaultInteractiveShellCommand(): string[] {
 }
 
 function checkpointBaseDir(): string {
-  const cacheBase =
-    process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
   return (
     process.env.GONDOLIN_CHECKPOINT_DIR ??
-    path.join(cacheBase, "gondolin", "checkpoints")
+    gondolinCacheDir("checkpoints")
   );
 }
 

--- a/host/bin/gondolin.ts
+++ b/host/bin/gondolin.ts
@@ -16,7 +16,10 @@ import { MemoryProvider, RealFSProvider } from "../src/vfs/node/index.ts";
 import { ReadonlyProvider } from "../src/vfs/readonly.ts";
 import { createHttpHooks } from "../src/http/hooks.ts";
 import { suggestHostsForSecret } from "../src/secret-host-suggestions.ts";
-import { ensureTrufflehogBinary, getTrufflehogStatus } from "../src/trufflehog.ts";
+import {
+  ensureTrufflehogBinary,
+  getTrufflehogStatus,
+} from "../src/build/trufflehog.ts";
 import {
   FrameReader,
   buildExecRequest,

--- a/host/bin/gondolin.ts
+++ b/host/bin/gondolin.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import net from "net";
 import os from "os";
 import path from "path";
+import readline from "node:readline/promises";
 import { PassThrough } from "stream";
 import { fileURLToPath } from "url";
 
@@ -14,6 +15,8 @@ import type { VirtualProvider } from "../src/vfs/node/index.ts";
 import { MemoryProvider, RealFSProvider } from "../src/vfs/node/index.ts";
 import { ReadonlyProvider } from "../src/vfs/readonly.ts";
 import { createHttpHooks } from "../src/http/hooks.ts";
+import { suggestHostsForSecret } from "../src/secret-host-suggestions.ts";
+import { ensureTrufflehogBinary, getTrufflehogStatus } from "../src/trufflehog.ts";
 import {
   FrameReader,
   buildExecRequest,
@@ -222,6 +225,7 @@ function usage() {
     "  build        Build custom guest assets (kernel, initramfs, rootfs)",
   );
   console.log("  image        Manage local image refs and objects");
+  console.log("  tools        Inspect/download managed helper tools");
   console.log("  help         Show this help");
   console.log("\nRun gondolin <command> --help for command-specific flags.");
 }
@@ -272,9 +276,9 @@ function bashUsage() {
   console.log(
     "  --allow-host HOST               Allow HTTP requests to host (can repeat)",
   );
-  console.log("  --host-secret NAME@HOST[,HOST...][=VALUE]");
+  console.log("  --host-secret NAME[=VALUE] | NAME@HOST[,HOST...][=VALUE]");
   console.log(
-    "                                  Add secret for specified hosts",
+    "                                  Add secret with explicit hosts or discover suggestions",
   );
   console.log(
     "                                  If =VALUE is omitted, reads from $NAME",
@@ -419,9 +423,9 @@ function execUsage() {
   console.log();
   console.log("Network Options (VM mode only):");
   console.log("  --allow-host HOST               Allow HTTP requests to host");
-  console.log("  --host-secret NAME@HOST[,HOST...][=VALUE]");
+  console.log("  --host-secret NAME[=VALUE] | NAME@HOST[,HOST...][=VALUE]");
   console.log(
-    "                                  Add secret for specified hosts",
+    "                                  Add secret with explicit hosts or discover suggestions",
   );
   console.log(
     "  --dns MODE                      DNS mode: synthetic|trusted|open (default: synthetic)",
@@ -575,12 +579,29 @@ function parseMount(spec: string): MountSpec {
 }
 
 function parseHostSecret(spec: string): SecretSpec {
-  // Format: NAME@HOST[,HOST...][=VALUE]
+  // Formats:
+  //   NAME
+  //   NAME=VALUE
+  //   NAME@HOST[,HOST...]
+  //   NAME@HOST[,HOST...]=VALUE
   const atIndex = spec.indexOf("@");
+
   if (atIndex === -1) {
-    throw new Error(
-      `Invalid host-secret format: ${spec} (expected NAME@HOST[,HOST...][=VALUE])`,
-    );
+    const eqIndex = spec.indexOf("=");
+    const name = (eqIndex === -1 ? spec : spec.slice(0, eqIndex)).trim();
+    if (!name) {
+      throw new Error(`Invalid host-secret format: ${spec} (empty name)`);
+    }
+
+    const value =
+      eqIndex === -1
+        ? process.env[name]
+        : spec.slice(eqIndex + 1);
+    if (value === undefined) {
+      throw new Error(`Environment variable ${name} not set for host-secret`);
+    }
+
+    return { name, value, hosts: [] };
   }
 
   const name = spec.slice(0, atIndex);
@@ -595,7 +616,6 @@ function parseHostSecret(spec: string): SecretSpec {
   let value: string;
 
   if (eqIndex === -1) {
-    // No explicit value, read from environment
     hostsStr = afterAt;
     const envValue = process.env[name];
     if (envValue === undefined) {
@@ -613,6 +633,117 @@ function parseHostSecret(spec: string): SecretSpec {
   }
 
   return { name, value, hosts };
+}
+
+async function promptForSuggestedSecretHosts(
+  secret: SecretSpec,
+  suggestions: Array<{
+    host: string;
+    file: string;
+    line: number;
+    snippet: string;
+    count: number;
+  }>,
+): Promise<string[]> {
+  if (!process.stdin.isTTY || !process.stderr.isTTY) {
+    throw new Error(
+      `Suggested hosts were found for ${secret.name}, but interactive confirmation requires a TTY. Re-run with --host-secret ${secret.name}@HOST[,HOST...]`,
+    );
+  }
+
+  process.stderr.write(`Suggested hosts for ${secret.name}:\n`);
+  suggestions.forEach((suggestion, index) => {
+    process.stderr.write(
+      `  [${index + 1}] ${suggestion.host}  (${suggestion.file}:${suggestion.line}, hits=${suggestion.count})\n`,
+    );
+    if (suggestion.snippet) {
+      process.stderr.write(`      ${suggestion.snippet}\n`);
+    }
+  });
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  try {
+    const answer = (
+      await rl.question(
+        "Accept all suggested hosts? [Y/n] (or enter comma-separated numbers): ",
+      )
+    )
+      .trim()
+      .toLowerCase();
+
+    if (!answer || answer === "y" || answer === "yes" || answer === "a") {
+      return suggestions.map((suggestion) => suggestion.host);
+    }
+    if (answer === "n" || answer === "no") {
+      return [];
+    }
+
+    const indexes = answer
+      .split(",")
+      .map((part) => Number(part.trim()))
+      .filter((value) => Number.isInteger(value));
+    if (indexes.length === 0) {
+      return [];
+    }
+
+    const selected = new Set<string>();
+    for (const index of indexes) {
+      const suggestion = suggestions[index - 1];
+      if (!suggestion) {
+        return [];
+      }
+      selected.add(suggestion.host);
+    }
+    return [...selected];
+  } finally {
+    rl.close();
+  }
+}
+
+async function resolveSecretHosts(secrets: SecretSpec[]): Promise<SecretSpec[]> {
+  const resolved: SecretSpec[] = [];
+
+  for (const secret of secrets) {
+    if (secret.hosts.length > 0) {
+      resolved.push(secret);
+      continue;
+    }
+
+    process.stderr.write(
+      `Discovering suggested hosts for secret ${secret.name} with trufflehog...\n`,
+    );
+    const suggestions = await suggestHostsForSecret({
+      secretName: secret.name,
+      secretValue: secret.value,
+      cwd: process.cwd(),
+    });
+
+    if (suggestions.length === 0) {
+      throw new Error(
+        `No suggested hosts were found for secret ${secret.name}. Provide hosts explicitly with --host-secret ${secret.name}@HOST[,HOST...]`,
+      );
+    }
+
+    const acceptedHosts = await promptForSuggestedSecretHosts(
+      secret,
+      suggestions,
+    );
+    if (acceptedHosts.length === 0) {
+      throw new Error(
+        `No hosts were accepted for secret ${secret.name}. Re-run with --host-secret ${secret.name}@HOST[,HOST...]`,
+      );
+    }
+
+    resolved.push({
+      ...secret,
+      hosts: acceptedHosts,
+    });
+  }
+
+  return resolved;
 }
 
 function parseSshCredential(spec: string): SshCredentialSpec {
@@ -1403,6 +1534,8 @@ async function runExec(argv: string[] = process.argv.slice(2)) {
     // Socket mode (direct virtio connection)
     runExecSocket(args);
   } else {
+    args.common.secrets = await resolveSecretHosts(args.common.secrets);
+
     // VM mode (in-process server)
     await runExecVm(args);
   }
@@ -1730,6 +1863,7 @@ function parseBashArgs(argv: string[]): BashArgs {
 
 async function runBash(argv: string[]) {
   const args = parseBashArgs(argv);
+  args.secrets = await resolveSecretHosts(args.secrets);
   const vmOptions = buildVmOptions(args);
   let vm: VM | null = null;
   let ingressAccess: { url: string; close(): Promise<void> } | null = null;
@@ -2634,6 +2768,117 @@ async function runBuild(argv: string[]) {
   }
 }
 
+function toolsUsage() {
+  console.log("Usage: gondolin tools <command> [options]");
+  console.log();
+  console.log("Inspect and manage Gondolin helper tools.");
+  console.log();
+  console.log("Commands:");
+  console.log("  trufflehog [--install] [--json]");
+  console.log("      Show managed trufflehog helper status");
+  console.log("      --install downloads it if missing");
+}
+
+async function runTools(argv: string[]) {
+  const [subcommand, ...rest] = argv;
+
+  if (
+    !subcommand ||
+    subcommand === "--help" ||
+    subcommand === "-h" ||
+    subcommand === "help"
+  ) {
+    toolsUsage();
+    process.exit(subcommand ? 0 : 1);
+  }
+
+  switch (subcommand) {
+    case "trufflehog": {
+      let install = false;
+      let asJson = false;
+
+      for (const arg of rest) {
+        if (arg === "--help" || arg === "-h") {
+          toolsUsage();
+          return;
+        }
+        if (arg === "--install") {
+          install = true;
+          continue;
+        }
+        if (arg === "--json") {
+          asJson = true;
+          continue;
+        }
+        throw new Error(`unexpected argument for tools trufflehog: ${arg}`);
+      }
+
+      if (install) {
+        await ensureTrufflehogBinary({
+          log: (msg) => process.stderr.write(`${msg}\n`),
+        });
+      }
+
+      const status = await getTrufflehogStatus();
+      const resolvedPath =
+        status.configuredPath ??
+        (status.configuredDir
+          ? path.join(status.configuredDir, "trufflehog")
+          : status.managedPath);
+      const source = status.configuredPath
+        ? "configured-path"
+        : status.configuredDir
+          ? "configured-dir"
+          : status.installed
+            ? "managed"
+            : "downloadable";
+
+      if (asJson) {
+        console.log(
+          JSON.stringify(
+            {
+              tool: "trufflehog",
+              version: status.version,
+              platform: status.platform,
+              source,
+              installed: status.installed,
+              configuredPath: status.configuredPath,
+              configuredDir: status.configuredDir,
+              managedPath: status.managedPath,
+              resolvedPath,
+              downloadUrl: status.downloadUrl,
+              ref: status.ref,
+              buildId: status.buildId,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      console.log("tool: trufflehog");
+      console.log(`ref: ${status.ref}`);
+      console.log(`build id: ${status.buildId}`);
+      console.log(`version: ${status.version}`);
+      console.log(`platform: ${status.platform}`);
+      console.log(`source: ${source}`);
+      console.log(`installed: ${status.installed ? "yes" : "no"}`);
+      console.log(`resolved path: ${resolvedPath}`);
+      if (status.configuredDir) {
+        console.log(`configured dir: ${status.configuredDir}`);
+      }
+      if (!status.configuredPath && !status.configuredDir) {
+        console.log(`managed path: ${status.managedPath}`);
+        console.log(`download url: ${status.downloadUrl}`);
+      }
+      return;
+    }
+    default:
+      throw new Error(`unknown tools command: ${subcommand}`);
+  }
+}
+
 function imageUsage() {
   console.log("Usage: gondolin image <command> [options]");
   console.log();
@@ -2929,6 +3174,9 @@ async function main() {
       return;
     case "image":
       await runImage(args);
+      return;
+    case "tools":
+      await runTools(args);
       return;
     default:
       console.error(`Unknown command: ${command}`);

--- a/host/src/assets.ts
+++ b/host/src/assets.ts
@@ -1,6 +1,5 @@
 import { createHash } from "crypto";
 import fs from "fs";
-import os from "os";
 import path from "path";
 import type {
   BuildConfig,
@@ -8,6 +7,7 @@ import type {
   OciPullPolicy,
   RootfsMode,
 } from "./build/config.ts";
+import { gondolinCacheDir } from "./cache.ts";
 
 let cachedAssetVersion: string | null = null;
 
@@ -43,15 +43,8 @@ function resolveAssetVersion(): string {
   return cachedAssetVersion;
 }
 
-function cacheBaseDir(): string {
-  return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
-}
-
 function getImageStoreDirectory(): string {
-  return (
-    process.env.GONDOLIN_IMAGE_STORE ??
-    path.join(cacheBaseDir(), "gondolin", "images")
-  );
+  return process.env.GONDOLIN_IMAGE_STORE ?? gondolinCacheDir("images");
 }
 
 function defaultGuestImageSelector(): string {

--- a/host/src/build/helpers.ts
+++ b/host/src/build/helpers.ts
@@ -1,0 +1,181 @@
+import { createHash, randomUUID } from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+export function cacheBaseDir(): string {
+  return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
+}
+
+export function normalizeSha256(value: unknown, label: string): string {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/i.test(value)) {
+    throw new Error(`invalid ${label}: expected sha256 hex string`);
+  }
+  return value.toLowerCase();
+}
+
+export function computeFileHash(filePath: string): string {
+  const hash = createHash("sha256");
+  const fd = fs.openSync(filePath, "r");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+
+  try {
+    let bytesRead = 0;
+    while ((bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null)) > 0) {
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  return hash.digest("hex");
+}
+
+export async function downloadToBuffer(
+  url: string,
+  expectedSha256: string | undefined,
+  userAgent: string,
+  options: {
+    downloadLabel?: string;
+    checksumLabel?: string;
+  } = {},
+): Promise<Buffer> {
+  const response = await fetch(url, {
+    headers: { "User-Agent": userAgent },
+  });
+  if (!response.ok) {
+    if (options.downloadLabel) {
+      throw new Error(
+        `failed to download ${options.downloadLabel}: ${response.status} ${response.statusText} (${url})`,
+      );
+    }
+    throw new Error(
+      `failed to download ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = Buffer.from(await response.arrayBuffer());
+  if (expectedSha256) {
+    const hash = createHash("sha256").update(data).digest("hex");
+    if (hash !== expectedSha256.toLowerCase()) {
+      if (options.checksumLabel) {
+        throw new Error(
+          `${options.checksumLabel} checksum mismatch for ${url}\n  expected: ${expectedSha256}\n  got:      ${hash}`,
+        );
+      }
+      throw new Error(
+        `downloaded checksum mismatch for ${url}\n  expected: ${expectedSha256}\n  got:      ${hash}`,
+      );
+    }
+  }
+  return data;
+}
+
+type RegistryCache<T> = {
+  /** source registry URL */
+  url: string;
+  /** HTTP etag from the last successful fetch */
+  etag?: string;
+  /** cached registry payload */
+  registry: T;
+};
+
+function loadRegistryCache<T>(
+  url: string,
+  storeDir: string,
+  cacheFileName: string,
+  parse: (raw: unknown, sourceUrl: string) => T,
+): RegistryCache<T> | null {
+  const cachePath = path.join(storeDir, cacheFileName);
+  if (!fs.existsSync(cachePath)) return null;
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as RegistryCache<T>;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (parsed.url !== url) return null;
+    return {
+      url,
+      etag: typeof parsed.etag === "string" ? parsed.etag : undefined,
+      registry: parse(parsed.registry as unknown, url),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function saveRegistryCache<T>(
+  cache: RegistryCache<T>,
+  storeDir: string,
+  cacheFileName: string,
+): void {
+  fs.mkdirSync(storeDir, { recursive: true });
+  const cachePath = path.join(storeDir, cacheFileName);
+  const tmpPath = `${cachePath}.tmp-${randomUUID().slice(0, 8)}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(cache, null, 2));
+  fs.renameSync(tmpPath, cachePath);
+}
+
+export async function fetchCachedJsonRegistry<T>(options: {
+  url: string;
+  storeDir: string;
+  cacheFileName: string;
+  userAgent: string;
+  parse: (raw: unknown, sourceUrl: string) => T;
+  label: string;
+}): Promise<T> {
+  const cached = loadRegistryCache(
+    options.url,
+    options.storeDir,
+    options.cacheFileName,
+    options.parse,
+  );
+
+  const headers: Record<string, string> = {
+    "User-Agent": options.userAgent,
+  };
+  if (cached?.etag) {
+    headers["If-None-Match"] = cached.etag;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(options.url, { headers });
+  } catch (error) {
+    if (cached) return cached.registry;
+    throw new Error(
+      `failed to fetch ${options.label} from ${options.url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (response.status === 304 && cached) {
+    return cached.registry;
+  }
+  if (!response.ok) {
+    if (cached) return cached.registry;
+    throw new Error(
+      `failed to fetch ${options.label}: ${response.status} ${response.statusText} (${options.url})`,
+    );
+  }
+
+  const text = await response.text();
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `failed to parse ${options.label} json from ${options.url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const registry = options.parse(raw, options.url);
+  saveRegistryCache(
+    {
+      url: options.url,
+      etag: response.headers.get("etag") ?? undefined,
+      registry,
+    },
+    options.storeDir,
+    options.cacheFileName,
+  );
+  return registry;
+}

--- a/host/src/build/helpers.ts
+++ b/host/src/build/helpers.ts
@@ -1,11 +1,8 @@
 import { createHash, randomUUID } from "crypto";
 import fs from "fs";
-import os from "os";
 import path from "path";
 
-export function cacheBaseDir(): string {
-  return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
-}
+export { cacheBaseDir } from "../cache.ts";
 
 export function normalizeSha256(value: unknown, label: string): string {
   if (typeof value !== "string" || !/^[0-9a-f]{64}$/i.test(value)) {

--- a/host/src/build/native.ts
+++ b/host/src/build/native.ts
@@ -5,6 +5,7 @@ import { createHash } from "crypto";
 import { execFileSync } from "child_process";
 
 import { buildAlpineImages } from "./alpine.ts";
+import { gondolinCacheDir } from "../cache.ts";
 import type { BuildConfig, Architecture } from "./config.ts";
 import { parseApkIndex } from "../alpine/packages.ts";
 import { decompressTarGz, extractTarGz, parseTar } from "../alpine/tar.ts";
@@ -91,7 +92,7 @@ export async function buildNative(
     warnOnKernelPackageMismatch(alpineConfig.rootfsPackages, kernelPackage);
   }
 
-  const cacheDir = path.join(os.homedir(), ".cache", "gondolin", "build");
+  const cacheDir = gondolinCacheDir("build");
 
   let rootfsInit: string | undefined;
   let initramfsInit: string | undefined;

--- a/host/src/build/sandbox-helpers.ts
+++ b/host/src/build/sandbox-helpers.ts
@@ -5,6 +5,13 @@ import path from "path";
 
 import { extractTarGz } from "../alpine/tar.ts";
 import type { Architecture } from "./config.ts";
+import {
+  cacheBaseDir,
+  computeFileHash,
+  downloadToBuffer,
+  fetchCachedJsonRegistry,
+  normalizeSha256,
+} from "./helpers.ts";
 
 const SANDBOX_HELPER_REGISTRY_SCHEMA = 1 as const;
 const SANDBOX_HELPER_MANIFEST_SCHEMA = 1 as const;
@@ -17,7 +24,6 @@ const HELPER_BUILD_ID_PATTERN =
 const HELPER_REF_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
 const HELPER_REF_NAME_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const HELPER_REF_TAG_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
-const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
 
 export const SANDBOX_HELPER_BINARY_NAMES = [
   "sandboxd",
@@ -131,19 +137,6 @@ type BuiltinSandboxHelperRegistry = {
   builds: Record<string, RegistrySandboxHelperSource>;
 };
 
-type RegistryCache = {
-  /** source registry URL */
-  url: string;
-  /** HTTP etag from the last successful fetch */
-  etag?: string;
-  /** cached registry payload */
-  registry: BuiltinSandboxHelperRegistry;
-};
-
-function cacheBaseDir(): string {
-  return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
-}
-
 export function getSandboxHelperStoreDirectory(): string {
   return (
     process.env.GONDOLIN_SANDBOX_HELPER_STORE ??
@@ -157,10 +150,6 @@ function sandboxHelperRegistryUrl(value?: string): string {
   if (explicit && explicit.length > 0) return explicit;
   if (envValue && envValue.length > 0) return envValue;
   return DEFAULT_SANDBOX_HELPER_REGISTRY_URL;
-}
-
-function registryCachePath(storeDir: string): string {
-  return path.join(storeDir, "builtin-sandbox-helper-registry-cache.json");
 }
 
 function helperObjectRootDir(storeDir: string): string {
@@ -179,13 +168,6 @@ function normalizeArchitecture(value: string | undefined | null): Architecture |
     return "x86_64";
   }
   return null;
-}
-
-function normalizeSha256(value: unknown, label: string): string {
-  if (typeof value !== "string" || !SHA256_PATTERN.test(value)) {
-    throw new Error(`invalid ${label}: expected sha256 hex string`);
-  }
-  return value.toLowerCase();
 }
 
 function normalizeHelperBuildId(value: string): string {
@@ -220,23 +202,6 @@ export function computeSandboxHelperBuildId(
   bytes[6] = (bytes[6] & 0x0f) | 0x50;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
   return bytesToUuid(bytes);
-}
-
-function computeFileHash(filePath: string): string {
-  const hash = createHash("sha256");
-  const fd = fs.openSync(filePath, "r");
-  const buffer = Buffer.allocUnsafe(1024 * 1024);
-
-  try {
-    let bytesRead = 0;
-    while ((bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null)) > 0) {
-      hash.update(buffer.subarray(0, bytesRead));
-    }
-  } finally {
-    fs.closeSync(fd);
-  }
-
-  return hash.digest("hex");
 }
 
 function hasValidRefNameSegments(name: string): boolean {
@@ -458,91 +423,19 @@ function parseBuiltinSandboxHelperRegistry(
   };
 }
 
-function loadRegistryCache(url: string, storeDir: string): RegistryCache | null {
-  const cachePath = registryCachePath(storeDir);
-  if (!fs.existsSync(cachePath)) return null;
-
-  try {
-    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as RegistryCache;
-    if (!parsed || typeof parsed !== "object") return null;
-    if (parsed.url !== url) return null;
-    const registry = parseBuiltinSandboxHelperRegistry(
-      parsed.registry as unknown,
-      url,
-    );
-    return {
-      url,
-      etag: typeof parsed.etag === "string" ? parsed.etag : undefined,
-      registry,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function saveRegistryCache(cache: RegistryCache, storeDir: string): void {
-  fs.mkdirSync(storeDir, { recursive: true });
-  const cachePath = registryCachePath(storeDir);
-  const tmpPath = `${cachePath}.tmp-${randomUUID().slice(0, 8)}`;
-  fs.writeFileSync(tmpPath, JSON.stringify(cache, null, 2));
-  fs.renameSync(tmpPath, cachePath);
-}
-
 async function fetchBuiltinSandboxHelperRegistry(
   options: Pick<ResolveSandboxHelperOptions, "registryUrl" | "storeDir">,
 ): Promise<BuiltinSandboxHelperRegistry> {
   const storeDir = options.storeDir ?? getSandboxHelperStoreDirectory();
   const url = sandboxHelperRegistryUrl(options.registryUrl);
-  const cached = loadRegistryCache(url, storeDir);
-
-  const headers: Record<string, string> = {
-    "User-Agent": "gondolin-sandbox-helper-registry",
-  };
-  if (cached?.etag) {
-    headers["If-None-Match"] = cached.etag;
-  }
-
-  let response: Response;
-  try {
-    response = await fetch(url, { headers });
-  } catch (error) {
-    if (cached) return cached.registry;
-    throw new Error(
-      `failed to fetch builtin sandbox helper registry from ${url}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  if (response.status === 304 && cached) {
-    return cached.registry;
-  }
-
-  if (!response.ok) {
-    if (cached) return cached.registry;
-    throw new Error(
-      `failed to fetch builtin sandbox helper registry: ${response.status} ${response.statusText} (${url})`,
-    );
-  }
-
-  const text = await response.text();
-  let raw: unknown;
-  try {
-    raw = JSON.parse(text);
-  } catch (error) {
-    throw new Error(
-      `failed to parse builtin sandbox helper registry json from ${url}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  const registry = parseBuiltinSandboxHelperRegistry(raw, url);
-  saveRegistryCache(
-    {
-      url,
-      etag: response.headers.get("etag") ?? undefined,
-      registry,
-    },
+  return await fetchCachedJsonRegistry({
+    url,
     storeDir,
-  );
-  return registry;
+    cacheFileName: "builtin-sandbox-helper-registry-cache.json",
+    userAgent: "gondolin-sandbox-helper-registry",
+    parse: parseBuiltinSandboxHelperRegistry,
+    label: "builtin sandbox helper registry",
+  });
 }
 
 function resolveRegistrySourceForRef(
@@ -775,35 +668,6 @@ function resolveSandboxHelperDirectory(
   };
 }
 
-async function downloadHelperArchive(
-  source: RegistrySandboxHelperSource,
-  archivePath: string,
-): Promise<void> {
-  const response = await fetch(source.url, {
-    headers: {
-      "User-Agent": "gondolin-sandbox-helper-fetch",
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `failed to download sandbox helper archive: ${response.status} ${response.statusText} (${source.url})`,
-    );
-  }
-
-  const data = Buffer.from(await response.arrayBuffer());
-  if (source.sha256) {
-    const got = createHash("sha256").update(data).digest("hex");
-    if (got !== source.sha256) {
-      throw new Error(
-        `downloaded sandbox helper checksum mismatch for ${source.url}\n  expected: ${source.sha256}\n  got:      ${got}`,
-      );
-    }
-  }
-
-  fs.writeFileSync(archivePath, data);
-}
-
 async function importSandboxHelpersFromSource(
   source: RegistrySandboxHelperSource,
   expectedBuildId: string,
@@ -816,7 +680,18 @@ async function importSandboxHelpersFromSource(
   const extractDir = path.join(tmpRoot, "extract");
 
   try {
-    await downloadHelperArchive(source, archivePath);
+    fs.writeFileSync(
+      archivePath,
+      await downloadToBuffer(
+        source.url,
+        source.sha256,
+        "gondolin-sandbox-helper-fetch",
+        {
+          downloadLabel: "sandbox helper archive",
+          checksumLabel: "downloaded sandbox helper",
+        },
+      ),
+    );
     fs.mkdirSync(extractDir, { recursive: true });
     await extractTarGz(archivePath, extractDir);
 

--- a/host/src/build/shared.ts
+++ b/host/src/build/shared.ts
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import { createHash } from "crypto";
 import { execFileSync, spawn, type SpawnOptions } from "child_process";
 
 import {
@@ -9,7 +8,9 @@ import {
   type AssetManifest,
 } from "../assets.ts";
 import type { BuildConfig, Architecture } from "./config.ts";
+import { computeFileHash } from "./helpers.ts";
 import { ensureSandboxHelperBinaries } from "./sandbox-helpers.ts";
+export { computeFileHash } from "./helpers.ts";
 
 /** Fixed output filenames for assets */
 export const KERNEL_FILENAME = "vmlinuz-virt";
@@ -489,24 +490,6 @@ async function buildGuestBinaries(
     { cwd: guestDir },
     log,
   );
-}
-
-/** Compute SHA256 hash of a file */
-export function computeFileHash(filePath: string): string {
-  const hash = createHash("sha256");
-  const fd = fs.openSync(filePath, "r");
-  const buffer = Buffer.allocUnsafe(1024 * 1024);
-
-  try {
-    let bytesRead = 0;
-    while ((bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null)) > 0) {
-      hash.update(buffer.subarray(0, bytesRead));
-    }
-  } finally {
-    fs.closeSync(fd);
-  }
-
-  return hash.digest("hex");
 }
 
 export function writeAssetManifest(

--- a/host/src/build/trufflehog.ts
+++ b/host/src/build/trufflehog.ts
@@ -3,7 +3,13 @@ import os from "os";
 import path from "path";
 import { randomUUID } from "crypto";
 
-import { extractTarGz } from "./alpine/tar.ts";
+import { extractTarGz } from "../alpine/tar.ts";
+import {
+  cacheBaseDir,
+  downloadToBuffer,
+  fetchCachedJsonRegistry,
+  normalizeSha256,
+} from "./helpers.ts";
 
 const TRUFFLEHOG_REGISTRY_SCHEMA = 1 as const;
 const DEFAULT_TRUFFLEHOG_REF = "trufflehog:3.95.3";
@@ -40,15 +46,6 @@ type BuiltinTrufflehogRegistry = {
   builds: Record<string, TrufflehogRegistryBuild>;
 };
 
-type RegistryCache = {
-  /** source registry url */
-  url: string;
-  /** http etag */
-  etag?: string;
-  /** cached registry */
-  registry: BuiltinTrufflehogRegistry;
-};
-
 export interface EnsureTrufflehogOptions {
   /** explicit cache/store directory */
   storeDir?: string;
@@ -73,10 +70,6 @@ export interface TrufflehogStatus {
   buildId: string;
 }
 
-function cacheBaseDir(): string {
-  return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
-}
-
 export function getTrufflehogStoreDirectory(): string {
   return path.join(cacheBaseDir(), "gondolin", "tools", "trufflehog");
 }
@@ -85,10 +78,6 @@ function trufflehogRegistryUrl(value?: string): string {
   const explicit = value?.trim();
   if (explicit) return explicit;
   return DEFAULT_TRUFFLEHOG_REGISTRY_URL;
-}
-
-function registryCachePath(storeDir: string): string {
-  return path.join(storeDir, "builtin-trufflehog-registry-cache.json");
 }
 
 function objectDir(storeDir: string, buildId: string): string {
@@ -134,13 +123,6 @@ function parseRef(reference: string): string {
     throw new Error(`invalid trufflehog ref: ${reference}`);
   }
   return trimmed;
-}
-
-function normalizeSha256(value: unknown, label: string): string {
-  if (typeof value !== "string" || !/^[0-9a-f]{64}$/i.test(value)) {
-    throw new Error(`invalid ${label}: expected sha256 hex string`);
-  }
-  return value.toLowerCase();
 }
 
 function parseRegistryBuild(
@@ -270,87 +252,20 @@ function parseBuiltinTrufflehogRegistry(
   return { schema: TRUFFLEHOG_REGISTRY_SCHEMA, refs, builds };
 }
 
-function loadRegistryCache(url: string, storeDir: string): RegistryCache | null {
-  const cachePath = registryCachePath(storeDir);
-  if (!fs.existsSync(cachePath)) return null;
-
-  try {
-    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as RegistryCache;
-    if (!parsed || typeof parsed !== "object") return null;
-    if (parsed.url !== url) return null;
-    return {
-      url,
-      etag: typeof parsed.etag === "string" ? parsed.etag : undefined,
-      registry: parseBuiltinTrufflehogRegistry(parsed.registry as unknown, url),
-    };
-  } catch {
-    return null;
-  }
-}
-
-function saveRegistryCache(cache: RegistryCache, storeDir: string): void {
-  fs.mkdirSync(storeDir, { recursive: true });
-  const cachePath = registryCachePath(storeDir);
-  const tmpPath = `${cachePath}.tmp-${randomUUID().slice(0, 8)}`;
-  fs.writeFileSync(tmpPath, JSON.stringify(cache, null, 2));
-  fs.renameSync(tmpPath, cachePath);
-}
-
 async function fetchBuiltinTrufflehogRegistry(options: {
   registryUrl?: string;
   storeDir?: string;
 }): Promise<BuiltinTrufflehogRegistry> {
   const storeDir = options.storeDir ?? getTrufflehogStoreDirectory();
   const url = trufflehogRegistryUrl(options.registryUrl);
-  const cached = loadRegistryCache(url, storeDir);
-
-  const headers: Record<string, string> = {
-    "User-Agent": "gondolin-trufflehog-registry",
-  };
-  if (cached?.etag) {
-    headers["If-None-Match"] = cached.etag;
-  }
-
-  let response: Response;
-  try {
-    response = await fetch(url, { headers });
-  } catch (error) {
-    if (cached) return cached.registry;
-    throw new Error(
-      `failed to fetch builtin trufflehog registry from ${url}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  if (response.status === 304 && cached) {
-    return cached.registry;
-  }
-  if (!response.ok) {
-    if (cached) return cached.registry;
-    throw new Error(
-      `failed to fetch builtin trufflehog registry: ${response.status} ${response.statusText} (${url})`,
-    );
-  }
-
-  const text = await response.text();
-  let raw: unknown;
-  try {
-    raw = JSON.parse(text);
-  } catch (error) {
-    throw new Error(
-      `failed to parse builtin trufflehog registry json from ${url}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  const registry = parseBuiltinTrufflehogRegistry(raw, url);
-  saveRegistryCache(
-    {
-      url,
-      etag: response.headers.get("etag") ?? undefined,
-      registry,
-    },
+  return await fetchCachedJsonRegistry({
+    url,
     storeDir,
-  );
-  return registry;
+    cacheFileName: "builtin-trufflehog-registry-cache.json",
+    userAgent: "gondolin-trufflehog-registry",
+    parse: parseBuiltinTrufflehogRegistry,
+    label: "builtin trufflehog registry",
+  });
 }
 
 async function resolveManagedBuild(
@@ -376,31 +291,6 @@ async function resolveManagedBuild(
     );
   }
   return { ref, buildId, build };
-}
-
-async function downloadToBuffer(
-  url: string,
-  expectedSha256: string | undefined,
-  userAgent: string,
-): Promise<Buffer> {
-  const response = await fetch(url, {
-    headers: { "User-Agent": userAgent },
-  });
-  if (!response.ok) {
-    throw new Error(
-      `failed to download ${url}: ${response.status} ${response.statusText}`,
-    );
-  }
-  const data = Buffer.from(await response.arrayBuffer());
-  if (expectedSha256) {
-    const hash = (await import("crypto")).createHash("sha256").update(data).digest("hex");
-    if (hash !== expectedSha256) {
-      throw new Error(
-        `downloaded checksum mismatch for ${url}\n  expected: ${expectedSha256}\n  got:      ${hash}`,
-      );
-    }
-  }
-  return data;
 }
 
 function findBinary(rootDir: string): string | null {

--- a/host/src/cache.ts
+++ b/host/src/cache.ts
@@ -1,0 +1,10 @@
+import os from "os";
+import path from "path";
+
+export function cacheBaseDir(): string {
+  return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
+}
+
+export function gondolinCacheDir(...paths: string[]): string {
+  return path.join(cacheBaseDir(), "gondolin", ...paths);
+}

--- a/host/src/images.ts
+++ b/host/src/images.ts
@@ -5,6 +5,7 @@ import os from "os";
 import path from "path";
 
 import { loadAssetManifest, loadGuestAssets } from "./assets.ts";
+import { gondolinCacheDir } from "./cache.ts";
 import type { Architecture } from "./build/config.ts";
 import { getHostNodeArchCached } from "./host/arch.ts";
 
@@ -126,15 +127,8 @@ type RegistryCache = {
   registry: BuiltinImageRegistry;
 };
 
-function cacheBaseDir(): string {
-  return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
-}
-
 export function getImageStoreDirectory(): string {
-  return (
-    process.env.GONDOLIN_IMAGE_STORE ??
-    path.join(cacheBaseDir(), "gondolin", "images")
-  );
+  return process.env.GONDOLIN_IMAGE_STORE ?? gondolinCacheDir("images");
 }
 
 function imageObjectRootDir(): string {

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -113,6 +113,11 @@ export type {
   SshExecPolicy,
 } from "./qemu/ssh.ts";
 export { HttpRequestBlockedError } from "./http/utils.ts";
+export {
+  suggestHostsForSecret,
+  type SecretHostSuggestion,
+  type SuggestSecretHostsOptions,
+} from "./secret-host-suggestions.ts";
 
 // SSH helpers
 export { getInfoFromSshExecRequest, type GitSshExecInfo } from "./ssh/exec.ts";

--- a/host/src/mitm.ts
+++ b/host/src/mitm.ts
@@ -1,10 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 
 import forge from "node-forge";
+import { gondolinCacheDir } from "./cache.ts";
 
 export type MitmCa = {
   /** ca private key */
@@ -18,9 +18,7 @@ export type MitmCa = {
 };
 
 export function getDefaultMitmCertDir() {
-  const cacheBase =
-    process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
-  return path.join(cacheBase, "gondolin", "ssl");
+  return gondolinCacheDir("ssl");
 }
 
 export function resolveMitmCertDir(mitmCertDir?: string) {

--- a/host/src/secret-host-suggestions.ts
+++ b/host/src/secret-host-suggestions.ts
@@ -8,24 +8,21 @@ const URL_RE = /https?:\/\/[^\s"'`<>]+/gi;
 const DETECTOR_SOURCE_SKIP_FILE_RE = /(?:^|\/)(?:[^/]+_test|[^/]+_integration_test)\.go$/;
 
 type TrufflehogScanResult = {
-  ok: boolean;
   stdout: string;
   stderr: string;
 };
 
 type TrufflehogFinding = {
   DetectorName?: string;
-  DetectorDescription?: string;
-  Verified?: boolean;
   ExtraData?: Record<string, string>;
 };
 
 export type SecretHostSuggestion = {
   /** suggested host name */
   host: string;
-  /** evidence file path relative to the scan root */
+  /** evidence file path relative to the scan root or synthetic `detector:<name>` */
   file: string;
-  /** evidence line number */
+  /** evidence line number or `0` for synthetic detector metadata */
   line: number;
   /** one-line evidence snippet */
   snippet: string;
@@ -108,7 +105,7 @@ async function runTrufflehogSecretDetection(
       child.on("error", reject);
       child.on("close", (code) => {
         if (code === 0 || code === 183) {
-          resolve({ ok: true, stdout, stderr });
+          resolve({ stdout, stderr });
           return;
         }
         reject(

--- a/host/src/secret-host-suggestions.ts
+++ b/host/src/secret-host-suggestions.ts
@@ -1,0 +1,449 @@
+import fs from "fs";
+import path from "path";
+import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+import { ensureTrufflehogBinary, ensureTrufflehogSourceDir } from "./trufflehog.ts";
+
+const MAX_TEXT_FILE_BYTES = 1024 * 1024;
+const SCAN_SKIP_NAMES = new Set([".git", "node_modules", "dist", ".cache"]);
+const HOSTNAME_RE = /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}\b/gi;
+const URL_RE = /https?:\/\/[^\s"'`<>]+/gi;
+const DETECTOR_SOURCE_SKIP_FILE_RE = /(?:^|\/)(?:[^/]+_test|[^/]+_integration_test)\.go$/;
+const trufflehogScanCache = new Map<string, Promise<TrufflehogScanResult>>();
+
+type TrufflehogScanResult = {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+};
+
+type TrufflehogFinding = {
+  DetectorName?: string;
+  DetectorDescription?: string;
+  Verified?: boolean;
+  ExtraData?: Record<string, string>;
+};
+
+export type SecretHostSuggestion = {
+  /** suggested host name */
+  host: string;
+  /** evidence file path relative to the scan root */
+  file: string;
+  /** evidence line number */
+  line: number;
+  /** one-line evidence snippet */
+  snippet: string;
+  /** evidence hit count for this host */
+  count: number;
+};
+
+export type SuggestSecretHostsOptions = {
+  /** secret env var name */
+  secretName: string;
+  /** secret value to search for */
+  secretValue: string;
+  /** repository or workspace path to scan */
+  cwd: string;
+};
+
+async function runTrufflehogScan(cwd: string): Promise<TrufflehogScanResult> {
+  const cached = trufflehogScanCache.get(cwd);
+  if (cached) {
+    return await cached;
+  }
+
+  const promise = (async () => {
+    const gitDir = path.join(cwd, ".git");
+    const isGitRepo = fs.existsSync(gitDir);
+    const args = isGitRepo
+      ? [
+          "git",
+          pathToFileURL(cwd).href,
+          "--json",
+          "--no-update",
+          "--results=verified,unknown,unverified",
+        ]
+      : [
+          "filesystem",
+          cwd,
+          "--json",
+          "--no-update",
+          "--results=verified,unknown,unverified",
+        ];
+
+    const binaryPath = await ensureTrufflehogBinary();
+
+    return await new Promise<TrufflehogScanResult>((resolve, reject) => {
+      const child = spawn(binaryPath, args, {
+        cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.on("error", (error) => {
+        reject(error);
+      });
+      child.on("close", (code) => {
+        if (code === 0 || code === 183) {
+          resolve({ ok: true, stdout, stderr });
+          return;
+        }
+        reject(
+          new Error(
+            `trufflehog scan failed with exit code ${code ?? "unknown"}${stderr ? `: ${stderr.trim()}` : ""}`,
+          ),
+        );
+      });
+    });
+  })();
+
+  trufflehogScanCache.set(cwd, promise);
+  try {
+    return await promise;
+  } catch (error) {
+    trufflehogScanCache.delete(cwd);
+    throw error;
+  }
+}
+
+function isProbablyText(buffer: Buffer): boolean {
+  const sample = buffer.subarray(0, Math.min(buffer.length, 1024));
+  for (const byte of sample) {
+    if (byte === 0) return false;
+  }
+  return true;
+}
+
+function walkFiles(root: string): string[] {
+  const files: string[] = [];
+  const stack = [root];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (SCAN_SKIP_NAMES.has(entry.name)) continue;
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile()) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function extractUrlHosts(snippet: string): string[] {
+  const hosts = new Set<string>();
+
+  for (const match of snippet.matchAll(URL_RE)) {
+    try {
+      const hostname = new URL(match[0]).hostname.toLowerCase();
+      if (hostname) hosts.add(hostname);
+    } catch {
+      // ignore invalid urls
+    }
+  }
+
+  return [...hosts];
+}
+
+function extractHosts(snippet: string): string[] {
+  const hosts = new Set<string>(extractUrlHosts(snippet));
+
+  for (const match of snippet.matchAll(HOSTNAME_RE)) {
+    const hostname = match[0].toLowerCase();
+    if (hostname) hosts.add(hostname);
+  }
+
+  return [...hosts];
+}
+
+function collectSuggestionsFromFile(
+  root: string,
+  filePath: string,
+  secretValue: string,
+): SecretHostSuggestion[] {
+  const stat = fs.statSync(filePath);
+  if (stat.size === 0 || stat.size > MAX_TEXT_FILE_BYTES) {
+    return [];
+  }
+
+  const buffer = fs.readFileSync(filePath);
+  if (!isProbablyText(buffer)) {
+    return [];
+  }
+
+  const content = buffer.toString("utf8");
+  if (!content.includes(secretValue)) {
+    return [];
+  }
+
+  const lines = content.split(/\r?\n/);
+  const suggestions: SecretHostSuggestion[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!lines[i].includes(secretValue)) continue;
+    const start = Math.max(0, i - 2);
+    const end = Math.min(lines.length, i + 3);
+    const snippet = lines.slice(start, end).join(" ").trim();
+    const hosts = extractHosts(snippet);
+    for (const host of hosts) {
+      suggestions.push({
+        host,
+        file: path.relative(root, filePath) || path.basename(filePath),
+        line: i + 1,
+        snippet: lines[i].trim().slice(0, 160),
+        count: 1,
+      });
+    }
+  }
+
+  return suggestions;
+}
+
+function parseTrufflehogJsonLines(stdout: string): TrufflehogFinding[] {
+  const findings: TrufflehogFinding[] = [];
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      findings.push(JSON.parse(trimmed) as TrufflehogFinding);
+    } catch {
+      // ignore non-json lines
+    }
+  }
+
+  return findings;
+}
+
+async function runTrufflehogSecretDetection(
+  secretValue: string,
+): Promise<TrufflehogFinding[]> {
+  const binaryPath = await ensureTrufflehogBinary();
+  const tmpRoot = fs.mkdtempSync(path.join(process.env.TMPDIR ?? "/tmp", "gondolin-secret-detect-"));
+  const filePath = path.join(tmpRoot, "secret.txt");
+
+  try {
+    fs.writeFileSync(filePath, `${secretValue}\n`, { mode: 0o600 });
+    const result = await new Promise<TrufflehogScanResult>((resolve, reject) => {
+      const child = spawn(
+        binaryPath,
+        [
+          "filesystem",
+          filePath,
+          "--json",
+          "--no-update",
+          "--no-verification",
+          "--results=verified,unknown,unverified",
+        ],
+        {
+          cwd: tmpRoot,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.on("error", reject);
+      child.on("close", (code) => {
+        if (code === 0 || code === 183) {
+          resolve({ ok: true, stdout, stderr });
+          return;
+        }
+        reject(
+          new Error(
+            `trufflehog secret detection failed with exit code ${code ?? "unknown"}${stderr ? `: ${stderr.trim()}` : ""}`,
+          ),
+        );
+      });
+    });
+
+    return parseTrufflehogJsonLines(result.stdout);
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+function collectDetectorSourceFiles(
+  detectorsDir: string,
+  detectorName: string,
+): string[] {
+  const files: string[] = [];
+  const needle = `DetectorType_${detectorName}`;
+  const stack = [detectorsDir];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".go")) continue;
+      const content = fs.readFileSync(fullPath, "utf8");
+      if (content.includes(needle)) {
+        files.push(fullPath);
+        const dir = path.dirname(fullPath);
+        for (const sibling of fs.readdirSync(dir)) {
+          const siblingPath = path.join(dir, sibling);
+          if (
+            siblingPath !== fullPath &&
+            sibling.endsWith(".go") &&
+            fs.statSync(siblingPath).isFile()
+          ) {
+            files.push(siblingPath);
+          }
+        }
+      }
+    }
+  }
+
+  return [...new Set(files)];
+}
+
+function normalizeSuggestedHost(host: string): string | null {
+  const trimmed = host.trim().toLowerCase();
+  if (!trimmed) return null;
+  if (trimmed === "localhost") return null;
+  if (!trimmed.includes(".")) return null;
+  return trimmed;
+}
+
+function collectSuggestionsFromDetectorSource(
+  sourceRoot: string,
+  detectorName: string,
+): SecretHostSuggestion[] {
+  const detectorsDir = path.join(sourceRoot, "pkg", "detectors");
+  if (!fs.existsSync(detectorsDir)) {
+    return [];
+  }
+
+  const sourceFiles = collectDetectorSourceFiles(detectorsDir, detectorName);
+  const suggestions: SecretHostSuggestion[] = [];
+
+  for (const filePath of sourceFiles) {
+    if (DETECTOR_SOURCE_SKIP_FILE_RE.test(filePath)) {
+      continue;
+    }
+
+    const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const hosts = extractUrlHosts(lines[i]);
+      for (const host of hosts) {
+        const normalized = normalizeSuggestedHost(host);
+        if (!normalized) continue;
+        suggestions.push({
+          host: normalized,
+          file: path.relative(sourceRoot, filePath),
+          line: i + 1,
+          snippet: lines[i].trim().slice(0, 160),
+          count: 1,
+        });
+      }
+    }
+  }
+
+  return suggestions;
+}
+
+function mergeSuggestions(
+  suggestions: SecretHostSuggestion[],
+): SecretHostSuggestion[] {
+  const merged = new Map<string, SecretHostSuggestion>();
+
+  for (const suggestion of suggestions) {
+    const existing = merged.get(suggestion.host);
+    if (!existing) {
+      merged.set(suggestion.host, suggestion);
+      continue;
+    }
+    existing.count += suggestion.count;
+  }
+
+  return [...merged.values()].sort(
+    (a, b) => b.count - a.count || a.host.localeCompare(b.host),
+  );
+}
+
+export async function suggestHostsForSecret(
+  options: SuggestSecretHostsOptions,
+): Promise<SecretHostSuggestion[]> {
+  if (!options.secretValue) {
+    return [];
+  }
+
+  const findings = await runTrufflehogSecretDetection(options.secretValue);
+  const detectorSuggestions: SecretHostSuggestion[] = [];
+
+  if (findings.length > 0) {
+    const sourceRoot = await ensureTrufflehogSourceDir();
+    for (const finding of findings) {
+      if (!finding.DetectorName) continue;
+      detectorSuggestions.push(
+        ...collectSuggestionsFromDetectorSource(
+          sourceRoot,
+          finding.DetectorName,
+        ),
+      );
+      for (const value of Object.values(finding.ExtraData ?? {})) {
+        for (const host of extractUrlHosts(value)) {
+          const normalized = normalizeSuggestedHost(host);
+          if (!normalized) continue;
+          detectorSuggestions.push({
+            host: normalized,
+            file: `detector:${finding.DetectorName}`,
+            line: 0,
+            snippet: value.slice(0, 160),
+            count: 1,
+          });
+        }
+      }
+    }
+  }
+
+  if (detectorSuggestions.length > 0) {
+    return mergeSuggestions(detectorSuggestions);
+  }
+
+  await runTrufflehogScan(options.cwd);
+
+  const repoSuggestions = walkFiles(options.cwd).flatMap((filePath) =>
+    collectSuggestionsFromFile(options.cwd, filePath, options.secretValue),
+  );
+
+  return mergeSuggestions(repoSuggestions);
+}
+
+export const __test = {
+  extractHosts,
+  extractUrlHosts,
+  parseTrufflehogJsonLines,
+  collectSuggestionsFromFile,
+  collectSuggestionsFromDetectorSource,
+  mergeSuggestions,
+};

--- a/host/src/secret-host-suggestions.ts
+++ b/host/src/secret-host-suggestions.ts
@@ -1,16 +1,11 @@
 import fs from "fs";
 import path from "path";
 import { spawn } from "node:child_process";
-import { pathToFileURL } from "node:url";
 
 import { ensureTrufflehogBinary, ensureTrufflehogSourceDir } from "./trufflehog.ts";
 
-const MAX_TEXT_FILE_BYTES = 1024 * 1024;
-const SCAN_SKIP_NAMES = new Set([".git", "node_modules", "dist", ".cache"]);
-const HOSTNAME_RE = /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}\b/gi;
 const URL_RE = /https?:\/\/[^\s"'`<>]+/gi;
 const DETECTOR_SOURCE_SKIP_FILE_RE = /(?:^|\/)(?:[^/]+_test|[^/]+_integration_test)\.go$/;
-const trufflehogScanCache = new Map<string, Promise<TrufflehogScanResult>>();
 
 type TrufflehogScanResult = {
   ok: boolean;
@@ -39,113 +34,9 @@ export type SecretHostSuggestion = {
 };
 
 export type SuggestSecretHostsOptions = {
-  /** secret env var name */
-  secretName: string;
   /** secret value to search for */
   secretValue: string;
-  /** repository or workspace path to scan */
-  cwd: string;
 };
-
-async function runTrufflehogScan(cwd: string): Promise<TrufflehogScanResult> {
-  const cached = trufflehogScanCache.get(cwd);
-  if (cached) {
-    return await cached;
-  }
-
-  const promise = (async () => {
-    const gitDir = path.join(cwd, ".git");
-    const isGitRepo = fs.existsSync(gitDir);
-    const args = isGitRepo
-      ? [
-          "git",
-          pathToFileURL(cwd).href,
-          "--json",
-          "--no-update",
-          "--results=verified,unknown,unverified",
-        ]
-      : [
-          "filesystem",
-          cwd,
-          "--json",
-          "--no-update",
-          "--results=verified,unknown,unverified",
-        ];
-
-    const binaryPath = await ensureTrufflehogBinary();
-
-    return await new Promise<TrufflehogScanResult>((resolve, reject) => {
-      const child = spawn(binaryPath, args, {
-        cwd,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-
-      let stdout = "";
-      let stderr = "";
-
-      child.stdout.setEncoding("utf8");
-      child.stderr.setEncoding("utf8");
-      child.stdout.on("data", (chunk: string) => {
-        stdout += chunk;
-      });
-      child.stderr.on("data", (chunk: string) => {
-        stderr += chunk;
-      });
-      child.on("error", (error) => {
-        reject(error);
-      });
-      child.on("close", (code) => {
-        if (code === 0 || code === 183) {
-          resolve({ ok: true, stdout, stderr });
-          return;
-        }
-        reject(
-          new Error(
-            `trufflehog scan failed with exit code ${code ?? "unknown"}${stderr ? `: ${stderr.trim()}` : ""}`,
-          ),
-        );
-      });
-    });
-  })();
-
-  trufflehogScanCache.set(cwd, promise);
-  try {
-    return await promise;
-  } catch (error) {
-    trufflehogScanCache.delete(cwd);
-    throw error;
-  }
-}
-
-function isProbablyText(buffer: Buffer): boolean {
-  const sample = buffer.subarray(0, Math.min(buffer.length, 1024));
-  for (const byte of sample) {
-    if (byte === 0) return false;
-  }
-  return true;
-}
-
-function walkFiles(root: string): string[] {
-  const files: string[] = [];
-  const stack = [root];
-
-  while (stack.length > 0) {
-    const current = stack.pop()!;
-    const entries = fs.readdirSync(current, { withFileTypes: true });
-
-    for (const entry of entries) {
-      if (SCAN_SKIP_NAMES.has(entry.name)) continue;
-      const fullPath = path.join(current, entry.name);
-      if (entry.isDirectory()) {
-        stack.push(fullPath);
-      } else if (entry.isFile()) {
-        files.push(fullPath);
-      }
-    }
-  }
-
-  return files;
-}
 
 function extractUrlHosts(snippet: string): string[] {
   const hosts = new Set<string>();
@@ -160,60 +51,6 @@ function extractUrlHosts(snippet: string): string[] {
   }
 
   return [...hosts];
-}
-
-function extractHosts(snippet: string): string[] {
-  const hosts = new Set<string>(extractUrlHosts(snippet));
-
-  for (const match of snippet.matchAll(HOSTNAME_RE)) {
-    const hostname = match[0].toLowerCase();
-    if (hostname) hosts.add(hostname);
-  }
-
-  return [...hosts];
-}
-
-function collectSuggestionsFromFile(
-  root: string,
-  filePath: string,
-  secretValue: string,
-): SecretHostSuggestion[] {
-  const stat = fs.statSync(filePath);
-  if (stat.size === 0 || stat.size > MAX_TEXT_FILE_BYTES) {
-    return [];
-  }
-
-  const buffer = fs.readFileSync(filePath);
-  if (!isProbablyText(buffer)) {
-    return [];
-  }
-
-  const content = buffer.toString("utf8");
-  if (!content.includes(secretValue)) {
-    return [];
-  }
-
-  const lines = content.split(/\r?\n/);
-  const suggestions: SecretHostSuggestion[] = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    if (!lines[i].includes(secretValue)) continue;
-    const start = Math.max(0, i - 2);
-    const end = Math.min(lines.length, i + 3);
-    const snippet = lines.slice(start, end).join(" ").trim();
-    const hosts = extractHosts(snippet);
-    for (const host of hosts) {
-      suggestions.push({
-        host,
-        file: path.relative(root, filePath) || path.basename(filePath),
-        line: i + 1,
-        snippet: lines[i].trim().slice(0, 160),
-        count: 1,
-      });
-    }
-  }
-
-  return suggestions;
 }
 
 function parseTrufflehogJsonLines(stdout: string): TrufflehogFinding[] {
@@ -426,24 +263,12 @@ export async function suggestHostsForSecret(
     }
   }
 
-  if (detectorSuggestions.length > 0) {
-    return mergeSuggestions(detectorSuggestions);
-  }
-
-  await runTrufflehogScan(options.cwd);
-
-  const repoSuggestions = walkFiles(options.cwd).flatMap((filePath) =>
-    collectSuggestionsFromFile(options.cwd, filePath, options.secretValue),
-  );
-
-  return mergeSuggestions(repoSuggestions);
+  return mergeSuggestions(detectorSuggestions);
 }
 
 export const __test = {
-  extractHosts,
   extractUrlHosts,
   parseTrufflehogJsonLines,
-  collectSuggestionsFromFile,
   collectSuggestionsFromDetectorSource,
   mergeSuggestions,
 };

--- a/host/src/secret-host-suggestions.ts
+++ b/host/src/secret-host-suggestions.ts
@@ -2,7 +2,10 @@ import fs from "fs";
 import path from "path";
 import { spawn } from "node:child_process";
 
-import { ensureTrufflehogBinary, ensureTrufflehogSourceDir } from "./trufflehog.ts";
+import {
+  ensureTrufflehogBinary,
+  ensureTrufflehogSourceDir,
+} from "./build/trufflehog.ts";
 
 const URL_RE = /https?:\/\/[^\s"'`<>]+/gi;
 const DETECTOR_SOURCE_SKIP_FILE_RE = /(?:^|\/)(?:[^/]+_test|[^/]+_integration_test)\.go$/;

--- a/host/src/secret-host-suggestions.ts
+++ b/host/src/secret-host-suggestions.ts
@@ -58,8 +58,10 @@ function parseTrufflehogJsonLines(stdout: string): TrufflehogFinding[] {
     if (!trimmed) continue;
     try {
       findings.push(JSON.parse(trimmed) as TrufflehogFinding);
-    } catch {
-      // ignore non-json lines
+    } catch (error) {
+      throw new Error(
+        `failed to parse trufflehog json line: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 

--- a/host/src/secret-host-suggestions.ts
+++ b/host/src/secret-host-suggestions.ts
@@ -236,29 +236,30 @@ export async function suggestHostsForSecret(
 
   const findings = await runTrufflehogSecretDetection(options.secretValue);
   const detectorSuggestions: SecretHostSuggestion[] = [];
+  const detectorNames = new Set<string>();
+  const sourceRoot = findings.some((finding) => finding.DetectorName)
+    ? await ensureTrufflehogSourceDir()
+    : null;
 
-  if (findings.length > 0) {
-    const sourceRoot = await ensureTrufflehogSourceDir();
-    for (const finding of findings) {
-      if (!finding.DetectorName) continue;
+  for (const finding of findings) {
+    if (finding.DetectorName && sourceRoot && !detectorNames.has(finding.DetectorName)) {
+      detectorNames.add(finding.DetectorName);
       detectorSuggestions.push(
-        ...collectSuggestionsFromDetectorSource(
-          sourceRoot,
-          finding.DetectorName,
-        ),
+        ...collectSuggestionsFromDetectorSource(sourceRoot, finding.DetectorName),
       );
-      for (const value of Object.values(finding.ExtraData ?? {})) {
-        for (const host of extractUrlHosts(value)) {
-          const normalized = normalizeSuggestedHost(host);
-          if (!normalized) continue;
-          detectorSuggestions.push({
-            host: normalized,
-            file: `detector:${finding.DetectorName}`,
-            line: 0,
-            snippet: value.slice(0, 160),
-            count: 1,
-          });
-        }
+    }
+    if (!finding.DetectorName) continue;
+    for (const value of Object.values(finding.ExtraData ?? {})) {
+      for (const host of extractUrlHosts(value)) {
+        const normalized = normalizeSuggestedHost(host);
+        if (!normalized) continue;
+        detectorSuggestions.push({
+          host: normalized,
+          file: `detector:${finding.DetectorName}`,
+          line: 0,
+          snippet: value.slice(0, 160),
+          count: 1,
+        });
       }
     }
   }

--- a/host/src/session-registry.ts
+++ b/host/src/session-registry.ts
@@ -1,8 +1,8 @@
 import fs from "fs";
 import net from "net";
-import os from "os";
 import path from "path";
 
+import { gondolinCacheDir } from "./cache.ts";
 import type { SandboxConnection } from "./sandbox/client.ts";
 import {
   decodeOutputFrame,
@@ -19,12 +19,8 @@ import {
   type StdinCommandMessage,
 } from "./sandbox/control-protocol.ts";
 
-const CACHE_BASE =
-  process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
-
 const SESSIONS_DIR =
-  process.env.GONDOLIN_SESSIONS_DIR ??
-  path.join(CACHE_BASE, "gondolin", "sessions");
+  process.env.GONDOLIN_SESSIONS_DIR ?? gondolinCacheDir("sessions");
 
 const MAX_REQUEST_ID = 0xffffffff;
 const INTERNAL_ID_FLOOR = 0x80000000;

--- a/host/src/trufflehog.ts
+++ b/host/src/trufflehog.ts
@@ -50,8 +50,6 @@ type RegistryCache = {
 };
 
 export interface EnsureTrufflehogOptions {
-  /** explicit binary path override */
-  binaryPath?: string;
   /** explicit cache/store directory */
   storeDir?: string;
   /** optional logger */
@@ -65,10 +63,6 @@ export interface TrufflehogStatus {
   version: string;
   /** resolved platform key */
   platform: SupportedPlatform;
-  /** configured binary override path */
-  configuredPath: string | null;
-  /** configured directory override */
-  configuredDir: string | null;
   /** managed install path */
   managedPath: string;
   /** whether a managed binary already exists */
@@ -84,17 +78,12 @@ function cacheBaseDir(): string {
 }
 
 export function getTrufflehogStoreDirectory(): string {
-  return (
-    process.env.GONDOLIN_TRUFFLEHOG_STORE ??
-    path.join(cacheBaseDir(), "gondolin", "tools", "trufflehog")
-  );
+  return path.join(cacheBaseDir(), "gondolin", "tools", "trufflehog");
 }
 
 function trufflehogRegistryUrl(value?: string): string {
-  const envValue = process.env.GONDOLIN_TRUFFLEHOG_REGISTRY_URL?.trim();
   const explicit = value?.trim();
   if (explicit) return explicit;
-  if (envValue) return envValue;
   return DEFAULT_TRUFFLEHOG_REGISTRY_URL;
 }
 
@@ -137,29 +126,6 @@ function resolveSupportedPlatform(
   throw new Error(
     `trufflehog helper is not available for this platform: ${platform}/${arch}`,
   );
-}
-
-function resolveConfiguredBinaryPath(explicit?: string): string | null {
-  const candidate =
-    explicit?.trim() || process.env.GONDOLIN_TRUFFLEHOG_PATH?.trim();
-  if (!candidate) return null;
-  const resolved = path.resolve(candidate);
-  if (!fs.existsSync(resolved)) {
-    throw new Error(`configured trufflehog binary does not exist: ${candidate}`);
-  }
-  return resolved;
-}
-
-function resolveConfiguredDirectory(): string | null {
-  const candidate = process.env.GONDOLIN_TRUFFLEHOG_DIR?.trim();
-  if (!candidate) return null;
-  const resolved = path.resolve(candidate);
-  if (!fs.existsSync(path.join(resolved, "trufflehog"))) {
-    throw new Error(
-      `configured trufflehog directory does not contain a trufflehog binary: ${candidate}`,
-    );
-  }
-  return resolved;
 }
 
 function parseRef(reference: string): string {
@@ -565,12 +531,6 @@ export async function ensureTrufflehogSourceDir(
 export async function ensureTrufflehogBinary(
   options: EnsureTrufflehogOptions = {},
 ): Promise<string> {
-  const configuredPath = resolveConfiguredBinaryPath(options.binaryPath);
-  if (configuredPath) return configuredPath;
-
-  const configuredDir = resolveConfiguredDirectory();
-  if (configuredDir) return path.join(configuredDir, "trufflehog");
-
   const storeDir = options.storeDir ?? getTrufflehogStoreDirectory();
   const platform = resolveSupportedPlatform();
   const { buildId, build } = await resolveManagedBuild(storeDir, platform);
@@ -580,8 +540,6 @@ export async function ensureTrufflehogBinary(
 export async function getTrufflehogStatus(
   options: Omit<EnsureTrufflehogOptions, "log"> = {},
 ): Promise<TrufflehogStatus> {
-  const configuredPath = resolveConfiguredBinaryPath(options.binaryPath);
-  const configuredDir = resolveConfiguredDirectory();
   const storeDir = options.storeDir ?? getTrufflehogStoreDirectory();
   const platform = resolveSupportedPlatform();
   const { ref, buildId, build } = await resolveManagedBuild(storeDir, platform);
@@ -590,8 +548,6 @@ export async function getTrufflehogStatus(
     ref,
     version: build.version,
     platform,
-    configuredPath,
-    configuredDir,
     managedPath,
     installed: fs.existsSync(managedPath),
     downloadUrl: build.url,

--- a/host/src/trufflehog.ts
+++ b/host/src/trufflehog.ts
@@ -1,0 +1,607 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { randomUUID } from "crypto";
+
+import { extractTarGz } from "./alpine/tar.ts";
+
+const TRUFFLEHOG_REGISTRY_SCHEMA = 1 as const;
+const DEFAULT_TRUFFLEHOG_REF = "trufflehog:3.95.3";
+const DEFAULT_TRUFFLEHOG_REGISTRY_URL =
+  "https://raw.githubusercontent.com/earendil-works/gondolin/main/builtin-trufflehog-registry.json";
+
+type SupportedPlatform =
+  | "darwin-arm64"
+  | "darwin-x64"
+  | "linux-arm64"
+  | "linux-x64";
+
+type TrufflehogRegistryBuild = {
+  /** tool version */
+  version: string;
+  /** target platform */
+  platform: SupportedPlatform;
+  /** binary archive url */
+  url: string;
+  /** binary archive checksum */
+  sha256?: string;
+  /** source archive url */
+  sourceUrl?: string;
+  /** source archive checksum */
+  sourceSha256?: string;
+};
+
+type BuiltinTrufflehogRegistry = {
+  /** registry schema version */
+  schema: typeof TRUFFLEHOG_REGISTRY_SCHEMA;
+  /** named refs mapped by platform to build ids */
+  refs: Record<string, Partial<Record<SupportedPlatform, string>>>;
+  /** build-id keyed sources */
+  builds: Record<string, TrufflehogRegistryBuild>;
+};
+
+type RegistryCache = {
+  /** source registry url */
+  url: string;
+  /** http etag */
+  etag?: string;
+  /** cached registry */
+  registry: BuiltinTrufflehogRegistry;
+};
+
+export interface EnsureTrufflehogOptions {
+  /** explicit binary path override */
+  binaryPath?: string;
+  /** explicit cache/store directory */
+  storeDir?: string;
+  /** optional logger */
+  log?: (msg: string) => void;
+}
+
+export interface TrufflehogStatus {
+  /** helper ref */
+  ref: string;
+  /** helper version */
+  version: string;
+  /** resolved platform key */
+  platform: SupportedPlatform;
+  /** configured binary override path */
+  configuredPath: string | null;
+  /** configured directory override */
+  configuredDir: string | null;
+  /** managed install path */
+  managedPath: string;
+  /** whether a managed binary already exists */
+  installed: boolean;
+  /** download url for this platform */
+  downloadUrl: string;
+  /** build id */
+  buildId: string;
+}
+
+function cacheBaseDir(): string {
+  return process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
+}
+
+export function getTrufflehogStoreDirectory(): string {
+  return (
+    process.env.GONDOLIN_TRUFFLEHOG_STORE ??
+    path.join(cacheBaseDir(), "gondolin", "tools", "trufflehog")
+  );
+}
+
+function trufflehogRegistryUrl(value?: string): string {
+  const envValue = process.env.GONDOLIN_TRUFFLEHOG_REGISTRY_URL?.trim();
+  const explicit = value?.trim();
+  if (explicit) return explicit;
+  if (envValue) return envValue;
+  return DEFAULT_TRUFFLEHOG_REGISTRY_URL;
+}
+
+function registryCachePath(storeDir: string): string {
+  return path.join(storeDir, "builtin-trufflehog-registry-cache.json");
+}
+
+function objectDir(storeDir: string, buildId: string): string {
+  return path.join(storeDir, "objects", buildId);
+}
+
+function installedBinaryPath(storeDir: string, buildId: string): string {
+  return path.join(objectDir(storeDir, buildId), "bin", "trufflehog");
+}
+
+function installedSourcePath(storeDir: string, buildId: string): string {
+  return path.join(objectDir(storeDir, buildId), "source");
+}
+
+function normalizeSupportedPlatform(value: string): SupportedPlatform | null {
+  if (value === "darwin-arm64") return value;
+  if (value === "darwin-x64") return value;
+  if (value === "linux-arm64") return value;
+  if (value === "linux-x64") return value;
+  return null;
+}
+
+function resolveSupportedPlatform(
+  platform: string = process.platform,
+  arch: string = process.arch,
+): SupportedPlatform {
+  if (platform === "darwin" && arch === "arm64") return "darwin-arm64";
+  if (platform === "darwin" && (arch === "x64" || arch === "amd64")) {
+    return "darwin-x64";
+  }
+  if (platform === "linux" && arch === "arm64") return "linux-arm64";
+  if (platform === "linux" && (arch === "x64" || arch === "amd64")) {
+    return "linux-x64";
+  }
+  throw new Error(
+    `trufflehog helper is not available for this platform: ${platform}/${arch}`,
+  );
+}
+
+function resolveConfiguredBinaryPath(explicit?: string): string | null {
+  const candidate =
+    explicit?.trim() || process.env.GONDOLIN_TRUFFLEHOG_PATH?.trim();
+  if (!candidate) return null;
+  const resolved = path.resolve(candidate);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`configured trufflehog binary does not exist: ${candidate}`);
+  }
+  return resolved;
+}
+
+function resolveConfiguredDirectory(): string | null {
+  const candidate = process.env.GONDOLIN_TRUFFLEHOG_DIR?.trim();
+  if (!candidate) return null;
+  const resolved = path.resolve(candidate);
+  if (!fs.existsSync(path.join(resolved, "trufflehog"))) {
+    throw new Error(
+      `configured trufflehog directory does not contain a trufflehog binary: ${candidate}`,
+    );
+  }
+  return resolved;
+}
+
+function parseRef(reference: string): string {
+  const trimmed = reference.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*:[A-Za-z0-9][A-Za-z0-9._+-]*$/.test(trimmed)) {
+    throw new Error(`invalid trufflehog ref: ${reference}`);
+  }
+  return trimmed;
+}
+
+function normalizeSha256(value: unknown, label: string): string {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/i.test(value)) {
+    throw new Error(`invalid ${label}: expected sha256 hex string`);
+  }
+  return value.toLowerCase();
+}
+
+function parseRegistryBuild(
+  raw: unknown,
+  where: string,
+  baseUrl: URL,
+): TrufflehogRegistryBuild {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`invalid ${where}: expected object`);
+  }
+  const rec = raw as Record<string, unknown>;
+  if (typeof rec.version !== "string" || !rec.version) {
+    throw new Error(`invalid ${where}.version: expected string`);
+  }
+  if (typeof rec.platform !== "string") {
+    throw new Error(`invalid ${where}.platform: expected string`);
+  }
+  const platform = normalizeSupportedPlatform(rec.platform);
+  if (!platform) {
+    throw new Error(`invalid ${where}.platform: ${String(rec.platform)}`);
+  }
+  if (typeof rec.url !== "string") {
+    throw new Error(`invalid ${where}.url: expected string`);
+  }
+
+  let url: string;
+  try {
+    url = new URL(rec.url, baseUrl).toString();
+  } catch {
+    throw new Error(`invalid ${where}.url: ${rec.url}`);
+  }
+
+  const build: TrufflehogRegistryBuild = {
+    version: rec.version,
+    platform,
+    url,
+  };
+
+  if (rec.sha256 !== undefined) {
+    build.sha256 = normalizeSha256(rec.sha256, `${where}.sha256`);
+  }
+  if (rec.sourceUrl !== undefined) {
+    if (typeof rec.sourceUrl !== "string") {
+      throw new Error(`invalid ${where}.sourceUrl: expected string`);
+    }
+    try {
+      build.sourceUrl = new URL(rec.sourceUrl, baseUrl).toString();
+    } catch {
+      throw new Error(`invalid ${where}.sourceUrl: ${rec.sourceUrl}`);
+    }
+  }
+  if (rec.sourceSha256 !== undefined) {
+    build.sourceSha256 = normalizeSha256(
+      rec.sourceSha256,
+      `${where}.sourceSha256`,
+    );
+  }
+
+  return build;
+}
+
+function parseBuiltinTrufflehogRegistry(
+  raw: unknown,
+  sourceUrl: string,
+): BuiltinTrufflehogRegistry {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("invalid builtin trufflehog registry: expected object");
+  }
+  const rec = raw as Record<string, unknown>;
+  if (rec.schema !== TRUFFLEHOG_REGISTRY_SCHEMA) {
+    throw new Error(
+      `invalid builtin trufflehog registry schema: expected ${TRUFFLEHOG_REGISTRY_SCHEMA}`,
+    );
+  }
+  const baseUrl = new URL(sourceUrl);
+
+  if (!rec.builds || typeof rec.builds !== "object" || Array.isArray(rec.builds)) {
+    throw new Error("invalid builtin trufflehog registry: builds must be an object");
+  }
+  const builds: Record<string, TrufflehogRegistryBuild> = {};
+  for (const [buildId, value] of Object.entries(rec.builds as Record<string, unknown>)) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(buildId)) {
+      throw new Error(`invalid builtin trufflehog build id: ${buildId}`);
+    }
+    builds[buildId] = parseRegistryBuild(value, `builds['${buildId}']`, baseUrl);
+  }
+
+  if (!rec.refs || typeof rec.refs !== "object" || Array.isArray(rec.refs)) {
+    throw new Error("invalid builtin trufflehog registry: refs must be an object");
+  }
+  const refs: Record<string, Partial<Record<SupportedPlatform, string>>> = {};
+  for (const [reference, value] of Object.entries(rec.refs as Record<string, unknown>)) {
+    const canonical = parseRef(reference);
+    if (canonical !== reference) {
+      throw new Error(`invalid builtin trufflehog registry ref key: ${reference}`);
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(`invalid registry ref '${reference}': expected object`);
+    }
+    const mapped: Partial<Record<SupportedPlatform, string>> = {};
+    for (const [platformKey, buildIdValue] of Object.entries(value as Record<string, unknown>)) {
+      const platform = normalizeSupportedPlatform(platformKey);
+      if (!platform) {
+        throw new Error(`invalid registry ref '${reference}' platform key: ${platformKey}`);
+      }
+      if (typeof buildIdValue !== "string") {
+        throw new Error(
+          `invalid refs['${reference}']['${platformKey}']: expected build id string`,
+        );
+      }
+      const build = builds[buildIdValue];
+      if (!build) {
+        throw new Error(
+          `invalid refs['${reference}']['${platformKey}']: unknown build id ${buildIdValue}`,
+        );
+      }
+      if (build.platform !== platform) {
+        throw new Error(
+          `invalid refs['${reference}']['${platformKey}']: platform mismatch for build ${buildIdValue}`,
+        );
+      }
+      mapped[platform] = buildIdValue;
+    }
+    refs[canonical] = mapped;
+  }
+
+  return { schema: TRUFFLEHOG_REGISTRY_SCHEMA, refs, builds };
+}
+
+function loadRegistryCache(url: string, storeDir: string): RegistryCache | null {
+  const cachePath = registryCachePath(storeDir);
+  if (!fs.existsSync(cachePath)) return null;
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as RegistryCache;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (parsed.url !== url) return null;
+    return {
+      url,
+      etag: typeof parsed.etag === "string" ? parsed.etag : undefined,
+      registry: parseBuiltinTrufflehogRegistry(parsed.registry as unknown, url),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function saveRegistryCache(cache: RegistryCache, storeDir: string): void {
+  fs.mkdirSync(storeDir, { recursive: true });
+  const cachePath = registryCachePath(storeDir);
+  const tmpPath = `${cachePath}.tmp-${randomUUID().slice(0, 8)}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(cache, null, 2));
+  fs.renameSync(tmpPath, cachePath);
+}
+
+async function fetchBuiltinTrufflehogRegistry(options: {
+  registryUrl?: string;
+  storeDir?: string;
+}): Promise<BuiltinTrufflehogRegistry> {
+  const storeDir = options.storeDir ?? getTrufflehogStoreDirectory();
+  const url = trufflehogRegistryUrl(options.registryUrl);
+  const cached = loadRegistryCache(url, storeDir);
+
+  const headers: Record<string, string> = {
+    "User-Agent": "gondolin-trufflehog-registry",
+  };
+  if (cached?.etag) {
+    headers["If-None-Match"] = cached.etag;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, { headers });
+  } catch (error) {
+    if (cached) return cached.registry;
+    throw new Error(
+      `failed to fetch builtin trufflehog registry from ${url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (response.status === 304 && cached) {
+    return cached.registry;
+  }
+  if (!response.ok) {
+    if (cached) return cached.registry;
+    throw new Error(
+      `failed to fetch builtin trufflehog registry: ${response.status} ${response.statusText} (${url})`,
+    );
+  }
+
+  const text = await response.text();
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `failed to parse builtin trufflehog registry json from ${url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const registry = parseBuiltinTrufflehogRegistry(raw, url);
+  saveRegistryCache(
+    {
+      url,
+      etag: response.headers.get("etag") ?? undefined,
+      registry,
+    },
+    storeDir,
+  );
+  return registry;
+}
+
+async function resolveManagedBuild(
+  storeDir: string,
+  platform: SupportedPlatform,
+): Promise<{ ref: string; buildId: string; build: TrufflehogRegistryBuild }> {
+  const registry = await fetchBuiltinTrufflehogRegistry({ storeDir });
+  const ref = parseRef(DEFAULT_TRUFFLEHOG_REF);
+  const entries = registry.refs[ref];
+  if (!entries) {
+    throw new Error(`trufflehog ref not found in builtin registry: ${ref}`);
+  }
+  const buildId = entries[platform];
+  if (!buildId) {
+    throw new Error(
+      `trufflehog ref '${ref}' has no registry source for ${platform}`,
+    );
+  }
+  const build = registry.builds[buildId];
+  if (!build) {
+    throw new Error(
+      `trufflehog ref '${ref}' points to unknown registry build id: ${buildId}`,
+    );
+  }
+  return { ref, buildId, build };
+}
+
+async function downloadToBuffer(
+  url: string,
+  expectedSha256: string | undefined,
+  userAgent: string,
+): Promise<Buffer> {
+  const response = await fetch(url, {
+    headers: { "User-Agent": userAgent },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `failed to download ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+  const data = Buffer.from(await response.arrayBuffer());
+  if (expectedSha256) {
+    const hash = (await import("crypto")).createHash("sha256").update(data).digest("hex");
+    if (hash !== expectedSha256) {
+      throw new Error(
+        `downloaded checksum mismatch for ${url}\n  expected: ${expectedSha256}\n  got:      ${hash}`,
+      );
+    }
+  }
+  return data;
+}
+
+function findBinary(rootDir: string): string | null {
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile() && entry.name === "trufflehog") {
+        return fullPath;
+      }
+    }
+  }
+  return null;
+}
+
+async function installManagedBinary(
+  storeDir: string,
+  buildId: string,
+  build: TrufflehogRegistryBuild,
+  log?: (msg: string) => void,
+): Promise<string> {
+  const targetPath = installedBinaryPath(storeDir, buildId);
+  if (fs.existsSync(targetPath)) return targetPath;
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-trufflehog-"));
+  const archivePath = path.join(tmpRoot, "trufflehog.tar.gz");
+  const extractDir = path.join(tmpRoot, "extract");
+  const installDir = path.dirname(targetPath);
+
+  try {
+    log?.(`Downloading trufflehog ${build.version} for ${build.platform}`);
+    fs.writeFileSync(
+      archivePath,
+      await downloadToBuffer(build.url, build.sha256, "gondolin-trufflehog-fetch"),
+    );
+    fs.mkdirSync(extractDir, { recursive: true });
+    await extractTarGz(archivePath, extractDir);
+
+    const binary = findBinary(extractDir);
+    if (!binary) {
+      throw new Error("downloaded trufflehog archive did not contain a trufflehog binary");
+    }
+
+    fs.mkdirSync(path.dirname(installDir), { recursive: true });
+    if (!fs.existsSync(targetPath)) {
+      const tmpInstallDir = `${installDir}.tmp-${randomUUID().slice(0, 8)}`;
+      try {
+        fs.mkdirSync(tmpInstallDir, { recursive: true });
+        fs.copyFileSync(binary, path.join(tmpInstallDir, "trufflehog"));
+        fs.chmodSync(path.join(tmpInstallDir, "trufflehog"), 0o755);
+        fs.renameSync(tmpInstallDir, installDir);
+      } catch (error) {
+        fs.rmSync(tmpInstallDir, { recursive: true, force: true });
+        if (!fs.existsSync(targetPath)) throw error;
+      }
+    }
+
+    fs.chmodSync(targetPath, 0o755);
+    return targetPath;
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+export async function ensureTrufflehogSourceDir(
+  options: Omit<EnsureTrufflehogOptions, "binaryPath"> = {},
+): Promise<string> {
+  const storeDir = options.storeDir ?? getTrufflehogStoreDirectory();
+  const platform = resolveSupportedPlatform();
+  const { buildId, build } = await resolveManagedBuild(storeDir, platform);
+  const targetDir = installedSourcePath(storeDir, buildId);
+  if (fs.existsSync(path.join(targetDir, "pkg", "detectors"))) {
+    return targetDir;
+  }
+  if (!build.sourceUrl) {
+    throw new Error(`trufflehog build ${buildId} does not provide sourceUrl`);
+  }
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-trufflehog-src-"));
+  const archivePath = path.join(tmpRoot, "trufflehog-source.tar.gz");
+  const extractDir = path.join(tmpRoot, "extract");
+
+  try {
+    options.log?.(`Downloading trufflehog source ${build.version}`);
+    fs.writeFileSync(
+      archivePath,
+      await downloadToBuffer(
+        build.sourceUrl,
+        build.sourceSha256,
+        "gondolin-trufflehog-source-fetch",
+      ),
+    );
+    fs.mkdirSync(extractDir, { recursive: true });
+    await extractTarGz(archivePath, extractDir);
+
+    const extractedRoot = fs
+      .readdirSync(extractDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(extractDir, entry.name))
+      .find((dir) => fs.existsSync(path.join(dir, "pkg", "detectors")));
+    if (!extractedRoot) {
+      throw new Error(
+        "downloaded trufflehog source archive did not contain pkg/detectors",
+      );
+    }
+
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+    if (!fs.existsSync(targetDir)) {
+      const tmpInstallDir = `${targetDir}.tmp-${randomUUID().slice(0, 8)}`;
+      try {
+        fs.cpSync(extractedRoot, tmpInstallDir, { recursive: true });
+        fs.renameSync(tmpInstallDir, targetDir);
+      } catch (error) {
+        fs.rmSync(tmpInstallDir, { recursive: true, force: true });
+        if (!fs.existsSync(targetDir)) throw error;
+      }
+    }
+
+    return targetDir;
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+export async function ensureTrufflehogBinary(
+  options: EnsureTrufflehogOptions = {},
+): Promise<string> {
+  const configuredPath = resolveConfiguredBinaryPath(options.binaryPath);
+  if (configuredPath) return configuredPath;
+
+  const configuredDir = resolveConfiguredDirectory();
+  if (configuredDir) return path.join(configuredDir, "trufflehog");
+
+  const storeDir = options.storeDir ?? getTrufflehogStoreDirectory();
+  const platform = resolveSupportedPlatform();
+  const { buildId, build } = await resolveManagedBuild(storeDir, platform);
+  return await installManagedBinary(storeDir, buildId, build, options.log);
+}
+
+export async function getTrufflehogStatus(
+  options: Omit<EnsureTrufflehogOptions, "log"> = {},
+): Promise<TrufflehogStatus> {
+  const configuredPath = resolveConfiguredBinaryPath(options.binaryPath);
+  const configuredDir = resolveConfiguredDirectory();
+  const storeDir = options.storeDir ?? getTrufflehogStoreDirectory();
+  const platform = resolveSupportedPlatform();
+  const { ref, buildId, build } = await resolveManagedBuild(storeDir, platform);
+  const managedPath = installedBinaryPath(storeDir, buildId);
+  return {
+    ref,
+    version: build.version,
+    platform,
+    configuredPath,
+    configuredDir,
+    managedPath,
+    installed: fs.existsSync(managedPath),
+    downloadUrl: build.url,
+    buildId,
+  };
+}
+
+export const __test = {
+  resolveSupportedPlatform,
+  installedBinaryPath,
+  installedSourcePath,
+  parseBuiltinTrufflehogRegistry,
+};

--- a/host/test/cli-http-hooks-options.test.ts
+++ b/host/test/cli-http-hooks-options.test.ts
@@ -49,6 +49,27 @@ test("buildVmOptions keeps implicit open egress for host secrets without --allow
   );
 });
 
+test("parseHostSecret supports host discovery mode from env", () => {
+  process.env.API_KEY = "secret-value";
+  try {
+    assert.deepEqual(__test.parseHostSecret("API_KEY"), {
+      name: "API_KEY",
+      value: "secret-value",
+      hosts: [],
+    });
+  } finally {
+    delete process.env.API_KEY;
+  }
+});
+
+test("parseHostSecret supports host discovery mode with inline value", () => {
+  assert.deepEqual(__test.parseHostSecret("API_KEY=secret-value"), {
+    name: "API_KEY",
+    value: "secret-value",
+    hosts: [],
+  });
+});
+
 test("buildVmOptions still honors explicit global allowlists", async () => {
   const vmOptions = __test.buildVmOptions(
     makeCommonOptions({

--- a/host/test/cli-tools-help.test.ts
+++ b/host/test/cli-tools-help.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+
+test("cli: gondolin tools --help renders usage", () => {
+  const hostDir = path.join(import.meta.dirname, "..");
+
+  const result = spawnSync(
+    process.execPath,
+    ["bin/gondolin.ts", "tools", "--help"],
+    {
+      cwd: hostDir,
+      env: process.env,
+      encoding: "utf8",
+      timeout: 15000,
+    },
+  );
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout ?? "", /Usage: gondolin tools/);
+  assert.match(result.stdout ?? "", /trufflehog/);
+});

--- a/host/test/secret-host-suggestions.test.ts
+++ b/host/test/secret-host-suggestions.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import test from "node:test";
+
+import { __test as suggestionTest } from "../src/secret-host-suggestions.ts";
+
+const {
+  collectSuggestionsFromDetectorSource,
+  collectSuggestionsFromFile,
+  extractHosts,
+  extractUrlHosts,
+  mergeSuggestions,
+  parseTrufflehogJsonLines,
+} = suggestionTest;
+
+test("extractHosts finds urls and bare hostnames", () => {
+  assert.deepEqual(extractHosts("see https://api.github.com/user and github.com"), [
+    "api.github.com",
+    "github.com",
+  ]);
+});
+
+test("extractUrlHosts only finds url hosts", () => {
+  assert.deepEqual(
+    extractUrlHosts('import "github.com/x/y" and https://api.openai.com/v1/me'),
+    ["api.openai.com"],
+  );
+});
+
+test("collectSuggestionsFromFile finds host evidence near secret value", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-secret-hosts-"));
+  const filePath = path.join(root, "sample.ts");
+
+  try {
+    fs.writeFileSync(
+      filePath,
+      [
+        'const baseUrl = "https://api.github.com";',
+        'const token = "secret-value";',
+        'fetch(`${baseUrl}/user`, { headers: { authorization: `Bearer ${token}` } });',
+      ].join("\n"),
+    );
+
+    const suggestions = collectSuggestionsFromFile(root, filePath, "secret-value");
+    assert.equal(suggestions.length, 1);
+    assert.equal(suggestions[0].host, "api.github.com");
+    assert.equal(suggestions[0].file, "sample.ts");
+    assert.equal(suggestions[0].line, 2);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("parseTrufflehogJsonLines parses newline-delimited json", () => {
+  const findings = parseTrufflehogJsonLines(
+    '{"DetectorName":"OpenAI"}\n{"DetectorName":"Github"}\n',
+  );
+  assert.deepEqual(findings.map((finding: any) => finding.DetectorName), [
+    "OpenAI",
+    "Github",
+  ]);
+});
+
+test("collectSuggestionsFromDetectorSource finds hosts in detector source", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-detector-src-"));
+  const detectorDir = path.join(root, "pkg", "detectors", "openai");
+  fs.mkdirSync(detectorDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(detectorDir, "openai.go"),
+    [
+      'package openai',
+      'import "github.com/wasilibs/go-re2"',
+      'func x() { _ = detectorspb.DetectorType_OpenAI }',
+      'const endpoint = "https://api.openai.com/v1/me"',
+    ].join("\n"),
+  );
+
+  try {
+    const suggestions = collectSuggestionsFromDetectorSource(root, "OpenAI");
+    assert.equal(suggestions.length, 1);
+    assert.equal(suggestions[0].host, "api.openai.com");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("mergeSuggestions deduplicates hosts and counts evidence", () => {
+  const merged = mergeSuggestions([
+    {
+      host: "api.github.com",
+      file: "a.ts",
+      line: 1,
+      snippet: "one",
+      count: 1,
+    },
+    {
+      host: "api.github.com",
+      file: "b.ts",
+      line: 2,
+      snippet: "two",
+      count: 1,
+    },
+  ]);
+
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].host, "api.github.com");
+  assert.equal(merged[0].count, 2);
+});

--- a/host/test/secret-host-suggestions.test.ts
+++ b/host/test/secret-host-suggestions.test.ts
@@ -8,49 +8,16 @@ import { __test as suggestionTest } from "../src/secret-host-suggestions.ts";
 
 const {
   collectSuggestionsFromDetectorSource,
-  collectSuggestionsFromFile,
-  extractHosts,
   extractUrlHosts,
   mergeSuggestions,
   parseTrufflehogJsonLines,
 } = suggestionTest;
-
-test("extractHosts finds urls and bare hostnames", () => {
-  assert.deepEqual(extractHosts("see https://api.github.com/user and github.com"), [
-    "api.github.com",
-    "github.com",
-  ]);
-});
 
 test("extractUrlHosts only finds url hosts", () => {
   assert.deepEqual(
     extractUrlHosts('import "github.com/x/y" and https://api.openai.com/v1/me'),
     ["api.openai.com"],
   );
-});
-
-test("collectSuggestionsFromFile finds host evidence near secret value", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gondolin-secret-hosts-"));
-  const filePath = path.join(root, "sample.ts");
-
-  try {
-    fs.writeFileSync(
-      filePath,
-      [
-        'const baseUrl = "https://api.github.com";',
-        'const token = "secret-value";',
-        'fetch(`${baseUrl}/user`, { headers: { authorization: `Bearer ${token}` } });',
-      ].join("\n"),
-    );
-
-    const suggestions = collectSuggestionsFromFile(root, filePath, "secret-value");
-    assert.equal(suggestions.length, 1);
-    assert.equal(suggestions[0].host, "api.github.com");
-    assert.equal(suggestions[0].file, "sample.ts");
-    assert.equal(suggestions[0].line, 2);
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
 });
 
 test("parseTrufflehogJsonLines parses newline-delimited json", () => {

--- a/host/test/trufflehog.test.ts
+++ b/host/test/trufflehog.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { __test } from "../src/trufflehog.ts";
+
+test("resolveSupportedPlatform supports gondolin host platforms", () => {
+  assert.equal(__test.resolveSupportedPlatform("darwin", "arm64"), "darwin-arm64");
+  assert.equal(__test.resolveSupportedPlatform("darwin", "x64"), "darwin-x64");
+  assert.equal(__test.resolveSupportedPlatform("linux", "arm64"), "linux-arm64");
+  assert.equal(__test.resolveSupportedPlatform("linux", "x64"), "linux-x64");
+});
+
+test("resolveSupportedPlatform rejects unsupported platforms", () => {
+  assert.throws(
+    () => __test.resolveSupportedPlatform("win32", "x64"),
+    /not available/,
+  );
+});
+
+test("installedBinaryPath includes object dir and build id", () => {
+  assert.equal(
+    __test.installedBinaryPath("/tmp/gondolin-tools", "build-123"),
+    path.join(
+      "/tmp/gondolin-tools",
+      "objects",
+      "build-123",
+      "bin",
+      "trufflehog",
+    ),
+  );
+});
+
+test("parseBuiltinTrufflehogRegistry parses refs and builds", () => {
+  const registry = __test.parseBuiltinTrufflehogRegistry(
+    {
+      schema: 1,
+      refs: {
+        "trufflehog:1.2.3": {
+          "linux-x64": "build-1",
+        },
+      },
+      builds: {
+        "build-1": {
+          version: "1.2.3",
+          platform: "linux-x64",
+          url: "https://example.com/trufflehog.tar.gz",
+        },
+      },
+    },
+    "https://example.com/registry.json",
+  );
+
+  assert.equal(registry.refs["trufflehog:1.2.3"]["linux-x64"], "build-1");
+  assert.equal(registry.builds["build-1"].platform, "linux-x64");
+});

--- a/host/test/trufflehog.test.ts
+++ b/host/test/trufflehog.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
 
-import { __test } from "../src/trufflehog.ts";
+import { __test } from "../src/build/trufflehog.ts";
 
 test("resolveSupportedPlatform supports gondolin host platforms", () => {
   assert.equal(__test.resolveSupportedPlatform("darwin", "arm64"), "darwin-arm64");


### PR DESCRIPTION
This PR expands the `--host-secret` CLI command to support not providing a host (was required before). Instead, when not provided, Gondolin will try to discover suggested hosts before starting the VM by using TruffleHog (matches secret's shape to suggested hosts, prompts the user to confirm the allowlist, and then proceeds with the accepted hosts. If no suggestions are found, it falls back to asking the user to rerun with the explicit host form).

To support that flow, Gondolin now manages TruffleHog as a helper asset (similar to sandbox helpers Gondolin-managed binaries).


https://github.com/user-attachments/assets/493f70c3-459d-40f0-8a96-7de8884cf88a

