### PR TITLE
feat: runtime add secret

### DIFF
--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -69,8 +69,6 @@ export type CreateHttpHooksOptions = {
   onResponse?: HttpHooks["onResponse"];
 };
 
-export type AddSecretOptions = SecretDefinition;
-
 export type UpdateSecretOptions = {
   /** updated secret value */
   value?: string;
@@ -93,7 +91,7 @@ export type SecretManager = {
   /** list configured secrets */
   listSecrets(): SecretManagerEntry[];
   /** add a new secret */
-  addSecret(name: string, secret: AddSecretOptions): void;
+  addSecret(name: string, secret: SecretDefinition): void;
   /** update an existing secret */
   updateSecret(name: string, options: UpdateSecretOptions): void;
   /** replace an existing secret with an empty string */

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -69,6 +69,8 @@ export type CreateHttpHooksOptions = {
   onResponse?: HttpHooks["onResponse"];
 };
 
+export type AddSecretOptions = SecretDefinition;
+
 export type UpdateSecretOptions = {
   /** updated secret value */
   value?: string;
@@ -90,6 +92,10 @@ export type SecretManagerEntry = {
 export type SecretManager = {
   /** list configured secrets */
   listSecrets(): SecretManagerEntry[];
+  /** guest-visible placeholder env vars for non-deleted secrets */
+  getEnv(): Record<string, string>;
+  /** add a new secret */
+  addSecret(name: string, secret: AddSecretOptions): void;
   /** update an existing secret */
   updateSecret(name: string, options: UpdateSecretOptions): void;
   /** replace an existing secret with an empty string */
@@ -195,6 +201,34 @@ export function createHttpHooks(
         hosts: [...entry.hosts],
         deleted: entry.deleted,
       }));
+    },
+    getEnv() {
+      return Object.fromEntries(
+        getSecretEntries()
+          .filter((entry) => !entry.deleted)
+          .map((entry) => [entry.name, entry.placeholder]),
+      );
+    },
+    addSecret(name, secret) {
+      if (secretEntries.has(name)) {
+        throw new Error(`secret already exists: ${name}`);
+      }
+      const placeholder = resolveSecretPlaceholder(name, secret);
+      assertSecretPlaceholderIsSafe(
+        name,
+        placeholder,
+        secret.value,
+        secretEntries.values(),
+      );
+      secretEntries.set(name, {
+        name,
+        placeholder,
+        value: secret.value,
+        revokedValues: [],
+        hosts: uniqueHosts(secret.hosts),
+        deleted: false,
+      });
+      env[name] = placeholder;
     },
     updateSecret(name, update) {
       const entry = getSecretEntry(name);

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -92,8 +92,6 @@ export type SecretManagerEntry = {
 export type SecretManager = {
   /** list configured secrets */
   listSecrets(): SecretManagerEntry[];
-  /** guest-visible placeholder env vars for non-deleted secrets */
-  getEnv(): Record<string, string>;
   /** add a new secret */
   addSecret(name: string, secret: AddSecretOptions): void;
   /** update an existing secret */
@@ -201,13 +199,6 @@ export function createHttpHooks(
         hosts: [...entry.hosts],
         deleted: entry.deleted,
       }));
-    },
-    getEnv() {
-      return Object.fromEntries(
-        getSecretEntries()
-          .filter((entry) => !entry.deleted)
-          .map((entry) => [entry.name, entry.placeholder]),
-      );
     },
     addSecret(name, secret) {
       const existing = secretEntries.get(name);

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -210,24 +210,34 @@ export function createHttpHooks(
       );
     },
     addSecret(name, secret) {
-      if (secretEntries.has(name)) {
+      const existing = secretEntries.get(name);
+      if (existing && !existing.deleted) {
         throw new Error(`secret already exists: ${name}`);
       }
-      const placeholder = resolveSecretPlaceholder(name, secret);
+      const placeholder =
+        existing?.placeholder ?? resolveSecretPlaceholder(name, secret);
       assertSecretPlaceholderIsSafe(
         name,
         placeholder,
         secret.value,
-        secretEntries.values(),
+        getSecretEntries().filter((entry) => entry.name !== name),
       );
-      secretEntries.set(name, {
-        name,
-        placeholder,
-        value: secret.value,
-        revokedValues: [],
-        hosts: uniqueHosts(secret.hosts),
-        deleted: false,
-      });
+      if (existing) {
+        existing.placeholder = placeholder;
+        existing.value = secret.value;
+        existing.revokedValues = [];
+        existing.hosts = uniqueHosts(secret.hosts);
+        existing.deleted = false;
+      } else {
+        secretEntries.set(name, {
+          name,
+          placeholder,
+          value: secret.value,
+          revokedValues: [],
+          hosts: uniqueHosts(secret.hosts),
+          deleted: false,
+        });
+      }
       env[name] = placeholder;
     },
     updateSecret(name, update) {

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -89,7 +89,6 @@ export {
   type CreateHttpHooksOptions,
   type CreateHttpHooksResult,
   type MakePlaceholderFuncOptions,
-  type AddSecretOptions,
   type SecretDefinition,
   type SecretManager,
   type SecretManagerEntry,

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -89,6 +89,7 @@ export {
   type CreateHttpHooksOptions,
   type CreateHttpHooksResult,
   type MakePlaceholderFuncOptions,
+  type AddSecretOptions,
   type SecretDefinition,
   type SecretManager,
   type SecretManagerEntry,

--- a/host/src/vm/core.ts
+++ b/host/src/vm/core.ts
@@ -52,6 +52,7 @@ import {
 } from "../session-registry.ts";
 import { createMitmCaProvider, resolveMitmMounts } from "./mitm-vfs.ts";
 import type { EnvInput, VMOptions, VmVfsOptions } from "./types.ts";
+import type { SecretManager } from "../http/hooks.ts";
 import {
   buildShellEnv,
   envInputToEntries,
@@ -142,6 +143,39 @@ const VFS_READY_ATTEMPTS = Math.max(
   1,
   Math.ceil(VFS_READY_TIMEOUT_MS / (VFS_READY_SLEEP_SECONDS * 1000)),
 );
+
+const RUNTIME_SECRETS_ENV_FILENAME = "secrets.env";
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function serializeSecretsEnvFile(env: Record<string, string>): string {
+  const entries = Object.entries(env).sort(([a], [b]) => a.localeCompare(b));
+  return entries.map(([key, value]) => `export ${key}=${shellQuote(value)}`).join("\n") + (entries.length > 0 ? "\n" : "");
+}
+
+function filterEnvInputByKeys(
+  env: EnvInput | undefined,
+  keys: Set<string>,
+): EnvInput | undefined {
+  if (!env || keys.size === 0) return env;
+  const filtered = envInputToEntries(env).filter(([key]) => !keys.has(key));
+  return filtered.length > 0 ? filtered.map(([key, value]) => `${key}=${value}`) : undefined;
+}
+
+function runtimeSecretNames(secretManager?: Pick<SecretManager, "listSecrets">): Set<string> {
+  return new Set((secretManager?.listSecrets() ?? []).map((entry) => entry.name));
+}
+
+function mergeExecEnvWithRuntimeSecrets(
+  baseEnv: EnvInput | undefined,
+  secretManager: Pick<SecretManager, "listSecrets" | "getEnv"> | undefined,
+  extraEnv?: EnvInput,
+): string[] | undefined {
+  const filteredBase = filterEnvInputByKeys(baseEnv, runtimeSecretNames(secretManager));
+  return mergeEnvInputs(filteredBase, mergeEnvInputs(secretManager?.getEnv(), extraEnv));
+}
 
 type ExecInput = string | string[];
 
@@ -239,6 +273,9 @@ export class VM {
   private checkpointed = false;
   private readonly baseOptionsForClone: VMOptions;
   private readonly defaultEnv: EnvInput | undefined;
+  /** runtime-managed secrets for newly spawned processes */
+  readonly secretManager?: SecretManager;
+  private gondolinEtcProvider: MemoryProvider | null = null;
   private connection: SandboxConnection | null = null;
   private connectPromise: Promise<void> | null = null;
   private readonly startSingleflight = new AsyncSingleflight<void>();
@@ -369,6 +406,10 @@ export class VM {
       options.sandbox?.netEnabled ?? true,
     );
 
+    this.secretManager = options.secretManager
+      ? this.createRuntimeSecretManager(options.secretManager)
+      : undefined;
+
     // Inject a guarded /etc/gondolin mount (host-authoritative ingress configuration)
     let gondolinMounts: Record<string, VirtualProvider> = {};
     let gondolinHooks: VfsHooks = {};
@@ -376,14 +417,14 @@ export class VM {
       const mountPaths = listMountPaths(options.vfs?.mounts);
       if (!mountPaths.includes("/etc/gondolin")) {
         const etcProvider = new MemoryProvider();
+        this.gondolinEtcProvider = etcProvider;
         this.gondolinEtc = createGondolinEtcMount(etcProvider);
-        gondolinMounts = {
-          "/etc/gondolin": etcProvider,
-        };
+        gondolinMounts["/etc/gondolin"] = etcProvider;
         gondolinHooks = createGondolinEtcHooks(
           this.gondolinEtc.listeners,
           etcProvider,
         ) as VfsHooks;
+        this.refreshRuntimeSecretsMount();
       }
     }
 
@@ -579,6 +620,38 @@ export class VM {
     }
   }
 
+  private createRuntimeSecretManager(secretManager: SecretManager): SecretManager {
+    return {
+      listSecrets: () => secretManager.listSecrets(),
+      getEnv: () => secretManager.getEnv(),
+      addSecret: (name, secret) => {
+        secretManager.addSecret(name, secret);
+        this.refreshRuntimeSecretsMount();
+      },
+      updateSecret: (name, options) => {
+        secretManager.updateSecret(name, options);
+        this.refreshRuntimeSecretsMount();
+      },
+      deleteSecret: (name) => {
+        secretManager.deleteSecret(name);
+        this.refreshRuntimeSecretsMount();
+      },
+    };
+  }
+
+  private refreshRuntimeSecretsMount() {
+    if (!this.gondolinEtcProvider || !this.secretManager) return;
+    const handle = this.gondolinEtcProvider.openSync(
+      `/${RUNTIME_SECRETS_ENV_FILENAME}`,
+      "w",
+    );
+    try {
+      handle.writeFileSync(serializeSecretsEnvFile(this.secretManager.getEnv()));
+    } finally {
+      handle.closeSync();
+    }
+  }
+
   /**
    * Start the VM.
    *
@@ -663,7 +736,10 @@ export class VM {
     const command = options.command ?? ["/bin/bash", "-i"];
     const shouldAttach = options.attach ?? process.stdin.isTTY;
 
-    const env = buildShellEnv(this.defaultEnv, options.env);
+    const env = buildShellEnv(
+      mergeExecEnvWithRuntimeSecrets(this.defaultEnv, this.secretManager),
+      options.env,
+    );
 
     const proc = this.exec(command, {
       env,
@@ -1111,7 +1187,12 @@ fi
     try {
       await this.start();
 
-      const mergedEnv = mergeEnvInputs(this.defaultEnv, options.env);
+      this.refreshRuntimeSecretsMount();
+      const mergedEnv = mergeExecEnvWithRuntimeSecrets(
+        this.defaultEnv,
+        this.secretManager,
+        options.env,
+      );
 
       const message = {
         type: "exec" as const,
@@ -2247,4 +2328,6 @@ export const __test = {
   mapToEnvArray,
   normalizeStartTimeoutMs,
   parseDiskSizeToBytes,
+  serializeSecretsEnvFile,
+  mergeExecEnvWithRuntimeSecrets,
 };

--- a/host/src/vm/core.ts
+++ b/host/src/vm/core.ts
@@ -168,13 +168,21 @@ function runtimeSecretNames(secretManager?: Pick<SecretManager, "listSecrets">):
   return new Set((secretManager?.listSecrets() ?? []).map((entry) => entry.name));
 }
 
+function runtimeSecretEnv(secretManager?: Pick<SecretManager, "listSecrets">): Record<string, string> {
+  return Object.fromEntries(
+    (secretManager?.listSecrets() ?? [])
+      .filter((entry) => !entry.deleted)
+      .map((entry) => [entry.name, entry.placeholder]),
+  );
+}
+
 function mergeExecEnvWithRuntimeSecrets(
   baseEnv: EnvInput | undefined,
-  secretManager: Pick<SecretManager, "listSecrets" | "getEnv"> | undefined,
+  secretManager: Pick<SecretManager, "listSecrets"> | undefined,
   extraEnv?: EnvInput,
 ): string[] | undefined {
   const filteredBase = filterEnvInputByKeys(baseEnv, runtimeSecretNames(secretManager));
-  return mergeEnvInputs(filteredBase, mergeEnvInputs(secretManager?.getEnv(), extraEnv));
+  return mergeEnvInputs(filteredBase, mergeEnvInputs(runtimeSecretEnv(secretManager), extraEnv));
 }
 
 type ExecInput = string | string[];
@@ -623,7 +631,6 @@ export class VM {
   private createRuntimeSecretManager(secretManager: SecretManager): SecretManager {
     return {
       listSecrets: () => secretManager.listSecrets(),
-      getEnv: () => secretManager.getEnv(),
       addSecret: (name, secret) => {
         secretManager.addSecret(name, secret);
         this.refreshRuntimeSecretsMount();
@@ -646,7 +653,7 @@ export class VM {
       "w",
     );
     try {
-      handle.writeFileSync(serializeSecretsEnvFile(this.secretManager.getEnv()));
+      handle.writeFileSync(serializeSecretsEnvFile(runtimeSecretEnv(this.secretManager)));
     } finally {
       handle.closeSync();
     }

--- a/host/src/vm/types.ts
+++ b/host/src/vm/types.ts
@@ -6,6 +6,7 @@ import type { RootfsMode } from "../build/config.ts";
 import type { SandboxServerOptions } from "../sandbox/server-options.ts";
 import type { VirtualProvider } from "../vfs/node/index.ts";
 import type { VfsHooks } from "../vfs/provider.ts";
+import type { SecretManager } from "../http/hooks.ts";
 
 export type EnvInput = string[] | Record<string, string>;
 
@@ -53,6 +54,8 @@ export type VMOptions = {
   vfs?: VmVfsOptions | null;
   /** default environment variables */
   env?: EnvInput;
+  /** runtime-managed secret placeholders for newly spawned processes */
+  secretManager?: SecretManager;
   /** vm memory size (qemu syntax, default: "1G") */
   memory?: string;
   /** vm cpu count (default: 2) */

--- a/host/test/http-hooks.test.ts
+++ b/host/test/http-hooks.test.ts
@@ -681,6 +681,51 @@ test("http hooks add secrets after creation", async () => {
   assert.equal(request.headers.get("authorization"), "Bearer secret-value");
 });
 
+test("http hooks can re-add a deleted secret", async () => {
+  const { httpHooks, secretManager } = createHttpHooks();
+
+  secretManager.addSecret("API_KEY", {
+    hosts: ["example.com"],
+    value: "old-secret",
+  });
+  const firstEnv = secretManager.getEnv();
+  secretManager.deleteSecret("API_KEY");
+  secretManager.addSecret("API_KEY", {
+    hosts: ["example.org"],
+    value: "new-secret",
+  });
+
+  const secondEnv = secretManager.getEnv();
+  assert.equal(secondEnv.API_KEY, firstEnv.API_KEY);
+
+  await assert.rejects(
+    () =>
+      httpHooks.onRequest!(
+        makeRequest({
+          method: "GET",
+          url: "https://example.com/data",
+          headers: {
+            authorization: `Bearer ${secondEnv.API_KEY}`,
+          },
+        }),
+      ),
+    (err) => err instanceof HttpRequestBlockedError,
+  );
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.org/data",
+      headers: {
+        authorization: `Bearer ${secondEnv.API_KEY}`,
+      },
+    }),
+  );
+
+  assert.equal(request.headers.get("authorization"), "Bearer new-secret");
+});
+
 test("http hooks update existing secrets after creation", async () => {
   const { httpHooks, env, secretManager } = createHttpHooks({
     secrets: {

--- a/host/test/http-hooks.test.ts
+++ b/host/test/http-hooks.test.ts
@@ -655,6 +655,32 @@ test("http hooks reject overlapping secret placeholders", () => {
   );
 });
 
+test("http hooks add secrets after creation", async () => {
+  const { httpHooks, secretManager } = createHttpHooks();
+
+  secretManager.addSecret("API_KEY", {
+    hosts: ["example.com"],
+    value: "secret-value",
+  });
+
+  const env = secretManager.getEnv();
+  assert.equal(typeof env.API_KEY, "string");
+  assert.match(env.API_KEY, /^GONDOLIN_SECRET_/);
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.com/data",
+      headers: {
+        authorization: `Bearer ${env.API_KEY}`,
+      },
+    }),
+  );
+
+  assert.equal(request.headers.get("authorization"), "Bearer secret-value");
+});
+
 test("http hooks update existing secrets after creation", async () => {
   const { httpHooks, env, secretManager } = createHttpHooks({
     secrets: {

--- a/host/test/http-hooks.test.ts
+++ b/host/test/http-hooks.test.ts
@@ -1,9 +1,22 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createHttpHooks, makePlaceholderFunc } from "../src/http/hooks.ts";
+import {
+  createHttpHooks,
+  makePlaceholderFunc,
+  type SecretManager,
+} from "../src/http/hooks.ts";
 import { HttpRequestBlockedError } from "../src/http/utils.ts";
 import { Request as UndiciRequest, Response as UndiciResponse } from "undici";
+
+function envFromSecretManager(secretManager: SecretManager): Record<string, string> {
+  return Object.fromEntries(
+    secretManager
+      .listSecrets()
+      .filter((entry) => !entry.deleted)
+      .map((entry) => [entry.name, entry.placeholder]),
+  );
+}
 
 function makeRequest(init: {
   method: string;
@@ -663,7 +676,7 @@ test("http hooks add secrets after creation", async () => {
     value: "secret-value",
   });
 
-  const env = secretManager.getEnv();
+  const env = envFromSecretManager(secretManager);
   assert.equal(typeof env.API_KEY, "string");
   assert.match(env.API_KEY, /^GONDOLIN_SECRET_/);
 
@@ -688,14 +701,14 @@ test("http hooks can re-add a deleted secret", async () => {
     hosts: ["example.com"],
     value: "old-secret",
   });
-  const firstEnv = secretManager.getEnv();
+  const firstEnv = envFromSecretManager(secretManager);
   secretManager.deleteSecret("API_KEY");
   secretManager.addSecret("API_KEY", {
     hosts: ["example.org"],
     value: "new-secret",
   });
 
-  const secondEnv = secretManager.getEnv();
+  const secondEnv = envFromSecretManager(secretManager);
   assert.equal(secondEnv.API_KEY, firstEnv.API_KEY);
 
   await assert.rejects(

--- a/host/test/vm-runtime-secrets.test.ts
+++ b/host/test/vm-runtime-secrets.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createHttpHooks } from "../src/http/hooks.ts";
+import { __test } from "../src/vm/core.ts";
+
+test("runtime secret env merge removes deleted startup secrets and adds new ones", () => {
+  const { env, secretManager } = createHttpHooks({
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "secret-value",
+      },
+    },
+  });
+
+  secretManager.deleteSecret("API_KEY");
+  secretManager.addSecret("OTHER_KEY", {
+    hosts: ["example.org"],
+    value: "other-secret",
+  });
+
+  const merged = __test.mergeExecEnvWithRuntimeSecrets(env, secretManager);
+  assert.ok(merged);
+  assert.equal(merged.some((entry: string) => entry.startsWith("API_KEY=")), false);
+  assert.equal(
+    merged.some((entry: string) => entry.startsWith("OTHER_KEY=")),
+    true,
+  );
+});
+
+test("runtime secret env file serializes placeholder exports", () => {
+  const text = __test.serializeSecretsEnvFile({
+    OPENAI_API_KEY: "GONDOLIN_SECRET_abc123",
+  });
+
+  assert.equal(
+    text,
+    "export OPENAI_API_KEY='GONDOLIN_SECRET_abc123'\n",
+  );
+});


### PR DESCRIPTION
Add runtime secret management for Gondolin HTTP-hook secrets. `secretManager` can now add, update, and delete secrets after VM startup, and newly spawned commands/shells pick up the current placeholder env without restarting the VM.

This keeps the existing security model: the guest only sees placeholders (also exposed via `/etc/gondolin/secrets.env`), while the real secret remains host-side and is only substituted on outbound requests to allowed hosts.