### PR TITLE
feat: single global secret

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -20,7 +20,9 @@ Instead, with `createHttpHooks({ secrets: ... })`:
 3. The guest only sees placeholders in env vars
 4. On outbound HTTP, the host replaces placeholders with real values (only for allowed hosts)
 
-By default, Gondolin uses `secretPlaceholderMode: "marker-env"`. Legacy random per-secret placeholders (`GONDOLIN_SECRET_<random>`) are still available via `secretPlaceholderMode: "legacy"`.
+By default, Gondolin uses `secretPlaceholderMode: "shared"`: generated secrets share one random marker and get placeholders like `<random-marker>.<normalized_secret_name>`.
+
+`secretPlaceholderMode: "unique"` instead gives each generated secret its own fully random placeholder like `GONDOLIN_SECRET_<random>`.
 
 If a placeholder is used for a disallowed host, the request is blocked.
 
@@ -47,8 +49,7 @@ the guest will not have placeholder env vars to reference.
 
 ## Custom Placeholders
 
-The default marker-based mode is a good fit for most secrets. If you need the guest-visible value to follow a specific token shape, you can still provide a custom placeholder explicitly.
-
+The default shared-marker mode is a good fit for most secrets. If you need the guest-visible value to follow a specific token shape, you can still provide a custom placeholder explicitly.
 
 A secret can provide a fixed placeholder string or a function that returns one.
 The function is called once when `createHttpHooks()` is called.
@@ -87,7 +88,7 @@ const { httpHooks, env } = createHttpHooks({
 Only the exact generated placeholder value is substituted; Gondolin does not
 replace arbitrary strings that merely look like matching tokens.
 
-If you need the pre-marker behavior for all unnamed secrets, set `secretPlaceholderMode: "legacy"`.
+If you want a fully random placeholder per unnamed secret instead of the shared-marker format, set `secretPlaceholderMode: "unique"`.
 
 ## What Is Substituted
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -15,10 +15,12 @@ Gondolin allows you to **not** put real secret values into the VM environment.
 
 Instead, with `createHttpHooks({ secrets: ... })`:
 
-1. The host generates placeholders (`GONDOLIN_SECRET_<random>` by default)
+1. The host generates placeholders (by default: `<random-marker>.<normalized_secret_name>`)
 2. You pass `env` + `httpHooks` into `VM.create(...)`
 3. The guest only sees placeholders in env vars
 4. On outbound HTTP, the host replaces placeholders with real values (only for allowed hosts)
+
+By default, Gondolin uses `secretPlaceholderMode: "marker-env"`. Legacy random per-secret placeholders (`GONDOLIN_SECRET_<random>`) are still available via `secretPlaceholderMode: "legacy"`.
 
 If a placeholder is used for a disallowed host, the request is blocked.
 
@@ -44,6 +46,9 @@ Important: pass **both** `httpHooks` and `env`. If you only pass `httpHooks`,
 the guest will not have placeholder env vars to reference.
 
 ## Custom Placeholders
+
+The default marker-based mode is a good fit for most secrets. If you need the guest-visible value to follow a specific token shape, you can still provide a custom placeholder explicitly.
+
 
 A secret can provide a fixed placeholder string or a function that returns one.
 The function is called once when `createHttpHooks()` is called.
@@ -81,6 +86,8 @@ const { httpHooks, env } = createHttpHooks({
 
 Only the exact generated placeholder value is substituted; Gondolin does not
 replace arbitrary strings that merely look like matching tokens.
+
+If you need the pre-marker behavior for all unnamed secrets, set `secretPlaceholderMode: "legacy"`.
 
 ## What Is Substituted
 

--- a/host/README.md
+++ b/host/README.md
@@ -124,7 +124,10 @@ await vm.close();
 ```
 
 The guest never sees the real secret values. It only gets placeholders.
-By default those placeholders look like `<random-marker>.<normalized_secret_name>`; legacy mode uses `GONDOLIN_SECRET_<random>`.
+By default (`secretPlaceholderMode: "shared"`) those placeholders look like
+`<random-marker>.<normalized_secret_name>`, where all generated secrets share
+one random marker. `secretPlaceholderMode: "unique"` instead gives each secret
+its own fully random placeholder like `GONDOLIN_SECRET_<random>`.
 Placeholders are substituted by the host in outbound HTTP headers, including
 `Authorization: Basic …` (the base64 token is decoded and placeholders in
 `username:password` are replaced).

--- a/host/README.md
+++ b/host/README.md
@@ -124,6 +124,7 @@ await vm.close();
 ```
 
 The guest never sees the real secret values. It only gets placeholders.
+By default those placeholders look like `<random-marker>.<normalized_secret_name>`; legacy mode uses `GONDOLIN_SECRET_<random>`.
 Placeholders are substituted by the host in outbound HTTP headers, including
 `Authorization: Basic …` (the base64 token is decoded and placeholders in
 `username:password` are replaced).

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -121,6 +121,11 @@ type SecretEntry = {
   deleted: boolean;
 };
 
+type SecretReplacementContext = {
+  mode: SecretPlaceholderMode;
+  marker?: string;
+};
+
 export function makePlaceholderFunc(
   options: MakePlaceholderFuncOptions,
 ): () => string {
@@ -247,6 +252,10 @@ export function createHttpHooks(
     assertRequestShape(request);
     const hostname = getHostname(request.url);
     const entries = getSecretEntries();
+    const replacementContext: SecretReplacementContext = {
+      mode: secretPlaceholderMode,
+      marker: secretMarker,
+    };
 
     // Defense-in-depth: if the request already contains real secret values (eg: because
     // it was constructed from a redirected hop), make sure we still enforce per-secret
@@ -262,12 +271,14 @@ export function createHttpHooks(
       request.headers,
       hostname,
       entries,
+      replacementContext,
     );
     const url = replaceSecretPlaceholdersInUrlParameters(
       request.url,
       hostname,
       entries,
       options.replaceSecretsInQuery ?? false,
+      replacementContext,
     );
 
     if (url === request.url) {
@@ -829,6 +840,7 @@ function replaceSecretPlaceholdersInHeaders(
   incomingHeaders: Headers,
   hostname: string,
   entries: SecretEntry[],
+  context: SecretReplacementContext,
 ): Headers {
   if (entries.length === 0) return incomingHeaders;
 
@@ -838,7 +850,12 @@ function replaceSecretPlaceholdersInHeaders(
     let updated = value;
 
     // Plaintext placeholder replacement (eg: `Authorization: Bearer $TOKEN`).
-    updated = replaceSecretPlaceholdersInString(updated, hostname, entries);
+    updated = replaceSecretPlaceholdersInString(
+      updated,
+      hostname,
+      entries,
+      context,
+    );
 
     // Basic auth uses base64 encoding of `username:password`, so placeholders
     // won't appear in the header value directly.
@@ -847,6 +864,7 @@ function replaceSecretPlaceholdersInHeaders(
       updated,
       hostname,
       entries,
+      context,
     );
 
     if (updated !== value) {
@@ -865,6 +883,7 @@ function replaceSecretPlaceholdersInUrlParameters(
   hostname: string,
   entries: SecretEntry[],
   enabled: boolean,
+  context: SecretReplacementContext,
 ): string {
   if (!enabled || entries.length === 0) return url;
 
@@ -885,11 +904,13 @@ function replaceSecretPlaceholdersInUrlParameters(
       name,
       hostname,
       entries,
+      context,
     );
     const updatedValue = replaceSecretPlaceholdersInString(
       value,
       hostname,
       entries,
+      context,
     );
     if (updatedName !== name || updatedValue !== value) changed = true;
     updatedParams.append(updatedName, updatedValue);
@@ -907,6 +928,7 @@ function replaceBasicAuthSecretPlaceholders(
   headerValue: string,
   hostname: string,
   entries: SecretEntry[],
+  context: SecretReplacementContext,
 ): string {
   // Only touch request headers that are expected to carry credentials.
   if (!/^(authorization|proxy-authorization)$/i.test(headerName)) {
@@ -932,6 +954,7 @@ function replaceBasicAuthSecretPlaceholders(
     decoded,
     hostname,
     entries,
+    context,
   );
   if (updatedDecoded === decoded) return headerValue;
 
@@ -943,23 +966,48 @@ function replaceSecretPlaceholdersInString(
   value: string,
   hostname: string,
   entries: SecretEntry[],
+  context: SecretReplacementContext,
 ): string {
   const secretValueRanges = entries.flatMap((entry) =>
     collectStringMatchRanges(value, entry.value),
   );
-  const replacements: Array<{
-    start: number;
-    end: number;
-    entry: SecretEntry;
-  }> = [];
+  const replacements = [
+    ...collectMarkerSecretReferenceRanges(value, entries, context),
+    ...collectLegacySecretReferenceRanges(value, entries, context),
+  ].filter(
+    (replacement) =>
+      !isRangeCoveredByAllowedValue(replacement, secretValueRanges),
+  );
+
+  return applySecretReplacements(value, hostname, replacements);
+}
+
+function collectLegacySecretReferenceRanges(
+  value: string,
+  entries: SecretEntry[],
+  context: SecretReplacementContext,
+): Array<{ start: number; end: number; entry: SecretEntry }> {
+  const markerPlaceholders =
+    context.mode === "marker-env" && context.marker
+      ? new Set(entries.map((entry) => `${context.marker}.${entry.identifier}`))
+      : null;
+  const replacements: Array<{ start: number; end: number; entry: SecretEntry }> = [];
 
   for (const entry of entries) {
+    if (markerPlaceholders?.has(entry.placeholder)) continue;
     for (const range of collectStringMatchRanges(value, entry.placeholder)) {
-      if (isRangeCoveredByAllowedValue(range, secretValueRanges)) continue;
       replacements.push({ ...range, entry });
     }
   }
 
+  return replacements;
+}
+
+function applySecretReplacements(
+  value: string,
+  hostname: string,
+  replacements: Array<{ start: number; end: number; entry: SecretEntry }>,
+): string {
   if (replacements.length === 0) return value;
 
   replacements.sort((a, b) => a.start - b.start || b.end - a.end);
@@ -983,6 +1031,45 @@ function replaceSecretPlaceholdersInString(
   }
 
   return updated + value.slice(offset);
+}
+
+function collectMarkerSecretReferenceRanges(
+  value: string,
+  entries: SecretEntry[],
+  context: SecretReplacementContext,
+): Array<{ start: number; end: number; entry: SecretEntry }> {
+  if (context.mode !== "marker-env" || !context.marker) {
+    return [];
+  }
+
+  const byIdentifier = new Map(entries.map((entry) => [entry.identifier, entry]));
+  const replacements: Array<{ start: number; end: number; entry: SecretEntry }> = [];
+  const prefix = `${context.marker}.`;
+
+  let searchFrom = 0;
+  while (searchFrom < value.length) {
+    const start = value.indexOf(prefix, searchFrom);
+    if (start === -1) break;
+
+    const identifierStart = start + prefix.length;
+    let identifierEnd = identifierStart;
+
+    while (identifierEnd < value.length) {
+      const ch = value[identifierEnd]!;
+      if (!/[A-Za-z0-9_-]/.test(ch)) break;
+      identifierEnd += 1;
+    }
+
+    const identifier = value.slice(identifierStart, identifierEnd);
+    const entry = byIdentifier.get(identifier);
+    if (identifier && entry) {
+      replacements.push({ start, end: identifierEnd, entry });
+    }
+
+    searchFrom = identifierStart;
+  }
+
+  return replacements;
 }
 
 function assertSecretAllowedForHost(

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -1042,7 +1042,13 @@ function collectMarkerSecretReferenceRanges(
     return [];
   }
 
-  const byIdentifier = new Map(entries.map((entry) => [entry.identifier, entry]));
+  const byIdentifier = new Map(
+    entries
+      .filter(
+        (entry) => entry.placeholder === `${context.marker}.${entry.identifier}`,
+      )
+      .map((entry) => [entry.identifier, entry]),
+  );
   const replacements: Array<{ start: number; end: number; entry: SecretEntry }> = [];
   const prefix = `${context.marker}.`;
 

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -113,6 +113,7 @@ export type CreateHttpHooksResult = {
 
 type SecretEntry = {
   name: string;
+  identifier: string;
   placeholder: string;
   value: string;
   revokedValues: string[];
@@ -161,11 +162,14 @@ export function createHttpHooks(
   const secretEntries = new Map<string, SecretEntry>();
 
   for (const [name, secret] of Object.entries(options.secrets ?? {})) {
+    const identifier = makeSecretIdentifier(name);
+    assertSecretIdentifierIsSafe(name, identifier, secretEntries.values());
     const placeholder = resolveSecretPlaceholder(
       name,
       secret,
       secretPlaceholderMode,
       secretMarker,
+      identifier,
     );
     assertSecretPlaceholderIsSafe(
       name,
@@ -176,6 +180,7 @@ export function createHttpHooks(
     env[name] = placeholder;
     secretEntries.set(name, {
       name,
+      identifier,
       placeholder,
       value: secret.value,
       revokedValues: [],
@@ -342,12 +347,13 @@ function resolveSecretPlaceholder(
   name: string,
   secret: SecretDefinition,
   mode: SecretPlaceholderMode,
-  marker?: string,
+  marker: string | undefined,
+  identifier: string,
 ): string {
   const placeholder =
     secret.placeholder === undefined
       ? mode === "marker-env"
-        ? `${marker}.${makeSecretIdentifier(name)}`
+        ? `${marker}.${identifier}`
         : makeDefaultSecretPlaceholder()
       : typeof secret.placeholder === "function"
         ? secret.placeholder()
@@ -369,7 +375,25 @@ function makeSecretMarker(): string {
 }
 
 function makeSecretIdentifier(name: string): string {
-  return name.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "_");
+  const identifier = name.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "_");
+  if (!identifier) {
+    throw new Error(`invalid secret identifier for ${name}`);
+  }
+  return identifier;
+}
+
+function assertSecretIdentifierIsSafe(
+  name: string,
+  identifier: string,
+  existingEntries: Iterable<SecretEntry>,
+): void {
+  for (const entry of existingEntries) {
+    if (identifier === entry.identifier) {
+      throw new Error(
+        `secret identifier for ${name} collides with secret identifier for ${entry.name}`,
+      );
+    }
+  }
 }
 
 function assertSecretPlaceholderIsSafe(

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -46,7 +46,7 @@ export const BASE62_ALPHABET =
 export const BASE64URL_ALPHABET =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
-export type SecretPlaceholderMode = "marker-env" | "legacy";
+export type SecretPlaceholderMode = "shared" | "unique";
 
 export type CreateHttpHooksOptions = {
   /** allowed host patterns (omitted = allow all, explicit empty = deny all) */
@@ -57,7 +57,7 @@ export type CreateHttpHooksOptions = {
   secrets?: Record<string, SecretDefinition>;
   /** placeholder replacement in URL query string (default: false) */
   replaceSecretsInQuery?: boolean;
-  /** secret placeholder strategy (default: `marker-env`) */
+  /** secret placeholder strategy (default: `shared`) */
   secretPlaceholderMode?: SecretPlaceholderMode;
   /** whether to block internal ip ranges (default: true) */
   blockInternalRanges?: boolean;
@@ -154,11 +154,9 @@ export function createHttpHooks(
   options: CreateHttpHooksOptions = {},
 ): CreateHttpHooksResult {
   const env: Record<string, string> = {};
-  const secretPlaceholderMode = options.secretPlaceholderMode ?? "marker-env";
+  const secretPlaceholderMode = options.secretPlaceholderMode ?? "shared";
   const secretMarker =
-    secretPlaceholderMode === "marker-env"
-      ? makeSecretMarker()
-      : undefined;
+    secretPlaceholderMode === "shared" ? makeSecretMarker() : undefined;
   const blockInternalRanges = options.blockInternalRanges ?? true;
   const configuredAllowedHosts =
     options.allowedHosts === undefined
@@ -176,7 +174,7 @@ export function createHttpHooks(
       secretMarker,
       identifier,
     );
-    if (!(secretPlaceholderMode === "marker-env" && secret.placeholder === undefined)) {
+    if (!(secretPlaceholderMode === "shared" && secret.placeholder === undefined)) {
       assertSecretPlaceholderIsSafe(
         name,
         placeholder,
@@ -365,7 +363,7 @@ function resolveSecretPlaceholder(
 ): string {
   const placeholder =
     secret.placeholder === undefined
-      ? mode === "marker-env"
+      ? mode === "shared"
         ? `${marker}.${identifier}`
         : makeDefaultSecretPlaceholder()
       : typeof secret.placeholder === "function"
@@ -990,7 +988,7 @@ function collectLegacySecretReferenceRanges(
   context: SecretReplacementContext,
 ): Array<{ start: number; end: number; entry: SecretEntry }> {
   const markerPlaceholders =
-    context.mode === "marker-env" && context.marker
+    context.mode === "shared" && context.marker
       ? new Set(entries.map((entry) => `${context.marker}.${entry.identifier}`))
       : null;
   const replacements: Array<{ start: number; end: number; entry: SecretEntry }> = [];
@@ -1040,7 +1038,7 @@ function collectMarkerSecretReferenceRanges(
   entries: SecretEntry[],
   context: SecretReplacementContext,
 ): Array<{ start: number; end: number; entry: SecretEntry }> {
-  if (context.mode !== "marker-env" || !context.marker) {
+  if (context.mode !== "shared" || !context.marker) {
     return [];
   }
 

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -361,11 +361,17 @@ function resolveSecretPlaceholder(
   marker: string | undefined,
   identifier: string,
 ): string {
+  if (mode === "shared" && !marker) {
+    throw new Error("shared secret placeholder mode requires a marker");
+  }
+
+  const generatedPlaceholder =
+    mode === "shared"
+      ? `${marker}.${identifier}`
+      : makeDefaultSecretPlaceholder();
   const placeholder =
     secret.placeholder === undefined
-      ? mode === "shared"
-        ? `${marker}.${identifier}`
-        : makeDefaultSecretPlaceholder()
+      ? generatedPlaceholder
       : typeof secret.placeholder === "function"
         ? secret.placeholder()
         : secret.placeholder;

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -46,6 +46,8 @@ export const BASE62_ALPHABET =
 export const BASE64URL_ALPHABET =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
+export type SecretPlaceholderMode = "marker-env" | "legacy";
+
 export type CreateHttpHooksOptions = {
   /** allowed host patterns (omitted = allow all, explicit empty = deny all) */
   allowedHosts?: string[];
@@ -55,6 +57,8 @@ export type CreateHttpHooksOptions = {
   secrets?: Record<string, SecretDefinition>;
   /** placeholder replacement in URL query string (default: false) */
   replaceSecretsInQuery?: boolean;
+  /** secret placeholder strategy (default: `marker-env`) */
+  secretPlaceholderMode?: SecretPlaceholderMode;
   /** whether to block internal ip ranges (default: true) */
   blockInternalRanges?: boolean;
   /** custom request policy callback */
@@ -144,6 +148,11 @@ export function createHttpHooks(
   options: CreateHttpHooksOptions = {},
 ): CreateHttpHooksResult {
   const env: Record<string, string> = {};
+  const secretPlaceholderMode = options.secretPlaceholderMode ?? "marker-env";
+  const secretMarker =
+    secretPlaceholderMode === "marker-env"
+      ? makeSecretMarker()
+      : undefined;
   const blockInternalRanges = options.blockInternalRanges ?? true;
   const configuredAllowedHosts =
     options.allowedHosts === undefined
@@ -152,7 +161,12 @@ export function createHttpHooks(
   const secretEntries = new Map<string, SecretEntry>();
 
   for (const [name, secret] of Object.entries(options.secrets ?? {})) {
-    const placeholder = resolveSecretPlaceholder(name, secret);
+    const placeholder = resolveSecretPlaceholder(
+      name,
+      secret,
+      secretPlaceholderMode,
+      secretMarker,
+    );
     assertSecretPlaceholderIsSafe(
       name,
       placeholder,
@@ -327,10 +341,14 @@ export function createHttpHooks(
 function resolveSecretPlaceholder(
   name: string,
   secret: SecretDefinition,
+  mode: SecretPlaceholderMode,
+  marker?: string,
 ): string {
   const placeholder =
     secret.placeholder === undefined
-      ? makeDefaultSecretPlaceholder()
+      ? mode === "marker-env"
+        ? `${marker}.${makeSecretIdentifier(name)}`
+        : makeDefaultSecretPlaceholder()
       : typeof secret.placeholder === "function"
         ? secret.placeholder()
         : secret.placeholder;
@@ -344,6 +362,14 @@ function resolveSecretPlaceholder(
 
 function makeDefaultSecretPlaceholder(): string {
   return `GONDOLIN_SECRET_${crypto.randomBytes(24).toString("hex")}`;
+}
+
+function makeSecretMarker(): string {
+  return crypto.randomBytes(24).toString("hex");
+}
+
+function makeSecretIdentifier(name: string): string {
+  return name.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "_");
 }
 
 function assertSecretPlaceholderIsSafe(

--- a/host/src/http/hooks.ts
+++ b/host/src/http/hooks.ts
@@ -176,12 +176,14 @@ export function createHttpHooks(
       secretMarker,
       identifier,
     );
-    assertSecretPlaceholderIsSafe(
-      name,
-      placeholder,
-      secret.value,
-      secretEntries.values(),
-    );
+    if (!(secretPlaceholderMode === "marker-env" && secret.placeholder === undefined)) {
+      assertSecretPlaceholderIsSafe(
+        name,
+        placeholder,
+        secret.value,
+        secretEntries.values(),
+      );
+    }
     env[name] = placeholder;
     secretEntries.set(name, {
       name,

--- a/host/src/index.ts
+++ b/host/src/index.ts
@@ -92,6 +92,7 @@ export {
   type SecretDefinition,
   type SecretManager,
   type SecretManagerEntry,
+  type SecretPlaceholderMode,
   type UpdateSecretOptions,
 } from "./http/hooks.ts";
 

--- a/host/test/cli-http-hooks-options.test.ts
+++ b/host/test/cli-http-hooks-options.test.ts
@@ -36,7 +36,7 @@ test("buildVmOptions keeps implicit open egress for host secrets without --allow
   assert.deepEqual(vmOptions.env, {
     API_KEY: vmOptions.env.API_KEY,
   });
-  assert.match(vmOptions.env.API_KEY, /^GONDOLIN_SECRET_/);
+  assert.match(vmOptions.env.API_KEY, /^[0-9a-f]{48}\.api_key$/);
   assert.equal(
     await vmOptions.httpHooks.isIpAllowed({
       hostname: "unrelated.example",

--- a/host/test/http-hooks.test.ts
+++ b/host/test/http-hooks.test.ts
@@ -452,6 +452,34 @@ test("http hooks replace secret placeholders", async () => {
   });
 
   assert.deepEqual(allowedHosts, ["*"]);
+  assert.match(env.API_KEY, /^[0-9a-f]{48}\.api_key$/);
+
+  const request = await runRequestHook(
+    httpHooks.onRequest!,
+    makeRequest({
+      method: "GET",
+      url: "https://example.com/data",
+      headers: {
+        authorization: `Bearer ${env.API_KEY}`,
+      },
+    }),
+  );
+
+  assert.equal(request.headers.get("authorization"), "Bearer secret-value");
+});
+
+test("http hooks support legacy secret placeholder mode", async () => {
+  const { httpHooks, env } = createHttpHooks({
+    secretPlaceholderMode: "legacy",
+    secrets: {
+      API_KEY: {
+        hosts: ["example.com"],
+        value: "secret-value",
+      },
+    },
+  });
+
+  assert.match(env.API_KEY, /^GONDOLIN_SECRET_/);
 
   const request = await runRequestHook(
     httpHooks.onRequest!,
@@ -1164,6 +1192,9 @@ test("http hooks replace secret placeholders in basic auth", async () => {
       },
     },
   });
+
+  assert.match(env.BASIC_USER, /^[0-9a-f]{48}\.basic_user$/);
+  assert.match(env.BASIC_PASS, /^[0-9a-f]{48}\.basic_pass$/);
 
   const placeholderToken = Buffer.from(
     `${env.BASIC_USER}:${env.BASIC_PASS}`,

--- a/host/test/http-hooks.test.ts
+++ b/host/test/http-hooks.test.ts
@@ -468,9 +468,9 @@ test("http hooks replace secret placeholders", async () => {
   assert.equal(request.headers.get("authorization"), "Bearer secret-value");
 });
 
-test("http hooks support legacy secret placeholder mode", async () => {
+test("http hooks support unique secret placeholder mode", async () => {
   const { httpHooks, env } = createHttpHooks({
-    secretPlaceholderMode: "legacy",
+    secretPlaceholderMode: "unique",
     secrets: {
       API_KEY: {
         hosts: ["example.com"],


### PR DESCRIPTION
This PR adds the proposal in #122. 

It adds a flag `'shared' | 'unique'`, with default `shared`. This makes HTTP-hook secret placeholders now use marker mode: guest env vars get `<random-marker>.<normalized_secret_name>` instead of per-secret random placeholders.

The host replacement path was updated to recognize these structured references in headers, basic auth, and optional query params, resolve them back to the configured secret by identifier, and then apply the existing allowlist/update/delete behavior. 

Unique `GONDOLIN_SECRET_<random>` placeholders remain available via `secretPlaceholderMode: "unique"`, and docs/tests were updated accordingly.