### PR TITLE
docs: add proxy support instructions for host-side downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Requirements:
 | ------------------------ | --------------------------------------------- |
 | `brew install qemu node` | `sudo apt install qemu-system-arm nodejs npm` |
 
+If you are behind a proxy, see
+[Proxy Support](docs/cli.md#proxy-support) for required configuration.
+
 Optional experimental libkrun backend setup:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -516,6 +516,35 @@ Image selectors accepted by `--image` and `sandbox.imagePath` strings:
 - `GONDOLIN_DEBUG`
     - Enable debug logging (see [Debug Logging](./debug.md))
 
+## Proxy Support
+
+Gondolin downloads guest images and sandbox helpers using Node.js built-in
+`fetch`. Node.js does not automatically use `HTTP_PROXY` / `HTTPS_PROXY`
+environment variables — you must opt in explicitly.
+
+If you are behind a proxy, set:
+
+```bash
+export NODE_OPTIONS="--use-env-proxy"
+```
+
+This tells Node.js to route `fetch` requests through the proxy specified by
+`HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
+
+You can combine this with your proxy settings:
+
+```bash
+export HTTP_PROXY=http://127.0.0.1:7890
+export HTTPS_PROXY=http://127.0.0.1:7890
+export NODE_OPTIONS="--use-env-proxy"
+
+npx @earendil-works/gondolin bash
+```
+
+> **Note:** This only affects host-side downloads (images, sandbox helpers).
+> Network traffic inside the VM is handled by Gondolin's own network stack
+> and is not subject to `NODE_OPTIONS`.
+
 
 ## Help
 


### PR DESCRIPTION
Node.js built-in fetch does not automatically use HTTP_PROXY/HTTPS_PROXY environment variables. Users behind a proxy need to opt in explicitly via NODE_OPTIONS='--use-env-proxy'.

Add a Proxy Support section to docs/cli.md explaining the issue and the fix, and link to it from the main README.md near the Requirements table.

Provide a brief description of the changes in this PR here.

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
