### PR TITLE
fix(guest): sync system clock from RTC at boot to avoid 'certificate not yet valid'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ guest/zig-cache/
 guest/zig-out/
 guest/.zig-cache/
 guest/image/out/
+image-out/
 guest/image/.cache/
 guest/fuzz/out/
 guest/fuzz/out-native/

--- a/guest/image/init
+++ b/guest/image/init
@@ -38,6 +38,25 @@ mount -t tmpfs tmpfs /run || log "[init] mount tmpfs failed"
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
+# Sync the system clock from the hardware RTC as early as possible.
+#
+# The host issues short-lived MITM TLS certificates whose notBefore is the
+# host wall-clock time. If the guest system clock lags behind the host (which
+# can happen depending on how the kernel initialises time on boot), freshly
+# minted certificates are seen as "certificate is not yet valid" and every
+# HTTPS request through the egress proxy (curl, apk, language runtimes, ...)
+# fails. The QEMU-exposed RTC tracks host time, so seeding the system clock
+# from it keeps the guest within the certificate validity window.
+if command -v hwclock > /dev/null 2>&1; then
+  if hwclock --hctosys --utc > /dev/null 2>&1 || hwclock -s > /dev/null 2>&1; then
+    log "[init] synced system clock from RTC: $(date -u 2>/dev/null)"
+  else
+    log "[init] hwclock RTC sync failed"
+  fi
+else
+  log "[init] hwclock not available; skipping RTC clock sync"
+fi
+
 mkdir -p /tmp /var/tmp /var/cache /var/log /root /home
 mount -t tmpfs tmpfs /tmp || log "[init] mount tmpfs /tmp failed"
 mount -t tmpfs tmpfs /root || log "[init] mount tmpfs /root failed"

--- a/images/alpine-base.json
+++ b/images/alpine-base.json
@@ -13,6 +13,7 @@
       "ca-certificates",
       "curl",
       "e2fsprogs",
+      "e2fsprogs-extra",
       "nodejs",
       "npm",
       "uv",


### PR DESCRIPTION
## Problem

Inside the guest, every HTTPS egress (curl, `apk`, Node/Python runtimes) can fail with:

```
SSL certificate problem: certificate is not yet valid
TLS: server certificate not trusted
```

against the `gondolin-mitm-ca` proxy certificates.

## Root cause

The host signs short-lived MITM TLS certificates with `notBefore` set to the **host wall-clock time**. When the **guest system clock lags behind the host**, those freshly minted certificates are seen as *not yet valid*, so the TLS handshake through the egress proxy is rejected.

Observed in an aarch64 QEMU guest:

- boot: `rtc-pl031` set the system clock to e.g. `06:57:39`
- guest system clock then ran behind host wall time
- host-signed cert `notBefore` was minutes **ahead** of guest time -> `not yet valid`
- the QEMU-exposed hardware RTC (`/dev/rtc0`) actually tracked host time correctly

Confirmed fix in-guest: `hwclock -s` immediately restored strict TLS (`curl https://api.github.com` -> 200, `apk update` over HTTPS -> OK), with no CA or repo changes.

There is currently no guest-side time sync and no host option to control this (no `clock`/`rtc`/`time` knobs in the SDK/CLI, no `-rtc` exposure), and guest `init` does not seed the clock.

## Change

Seed the system clock from the hardware RTC early in `guest/image/init` (after `/dev` is mounted, before networking/CA setup). Tries `hwclock --hctosys --utc`, falls back to `hwclock -s`, and degrades gracefully (logs and continues) when `hwclock` is unavailable.

## Notes

- `busybox` (present in the Alpine base image) provides an `hwclock` applet, so this is available by default.
- Pure addition; no behavior change when the clock is already correct.
- Alternative/complementary host-side fix would be ensuring QEMU is launched with `-rtc base=utc,clock=host`; this guest-side change is the minimal self-contained fix.