### PR TITLE
Prevent unhandled rejections in writeGuestFile and deleteGuestFile, as in readGuestFileStream

### DIFF
--- a/host/src/sandbox/server-ops.ts
+++ b/host/src/sandbox/server-ops.ts
@@ -269,6 +269,7 @@ export class SandboxServerOps {
       resolveDone = resolve;
       rejectDone = reject;
     });
+    void done.catch(() => {});
 
     this.fileOps.set(id, {
       kind: "write",
@@ -345,6 +346,7 @@ export class SandboxServerOps {
       resolveDone = resolve;
       rejectDone = reject;
     });
+    void done.catch(() => {});
 
     this.fileOps.set(id, {
       kind: "delete",


### PR DESCRIPTION
In `host/src/sandbox/server-ops.ts`, there is a `void done.catch(() => {});` line inside the `readGuestFileStream` method. This prevents an unhandled rejection from crashing the whole process if the operation fails before `done` is awaited. (For example, an abort can cause a rejection before we hit `await done`.)

This PR adds the same handling to `writeGuestFile` and `deleteGuestFile`, which have the same problem as `readGuestFileStream` but don't have the no-op handler to fix it.

(I hit this unhandled rejection when aborting a task running in a Gondolin sandbox.)

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`. _(Author's note: uh... where?)_

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
