### PR TITLE
Add e2fsprogs-extra to alpine-base - Fixes #132

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ options for configuring filesystem mounts and mediated network egress policy.
 
 - `--rootfs-size SIZE`
     - Ensure the rootfs virtual disk is at least `SIZE` before boot (for example `2G`)
-    - Requires `resize2fs` in the guest image (`e2fsprogs` on Alpine)
+    - Requires `resize2fs` in the guest image (`e2fsprogs-extra` on Alpine)
 
 Examples:
 

--- a/docs/sdk-storage.md
+++ b/docs/sdk-storage.md
@@ -133,7 +133,7 @@ The base rootfs image is not modified when using the default `cow` mode. When
 combined with `rootfs.mode="memory"`, Gondolin uses a temporary qcow2 overlay so
 the guest-side filesystem resize survives for the lifetime of that VM.
 
-The guest image must include `resize2fs` (Alpine package: `e2fsprogs`). Newer
+The guest image must include `resize2fs` (Alpine package: `e2fsprogs-extra`). Newer
 `alpine-base` images include it; custom images should add it to
 `alpine.rootfsPackages` when using `rootfs.size`.
 

--- a/host/src/build/config.ts
+++ b/host/src/build/config.ts
@@ -201,6 +201,7 @@ export function getDefaultBuildConfig(): BuildConfig {
         "ca-certificates",
         "curl",
         "e2fsprogs",
+        "e2fsprogs-extra",
         "nodejs",
         "npm",
         "uv",

--- a/images/alpine-base.json
+++ b/images/alpine-base.json
@@ -13,6 +13,7 @@
       "ca-certificates",
       "curl",
       "e2fsprogs",
+      "e2fsprogs-extra",
       "nodejs",
       "npm",
       "uv",


### PR DESCRIPTION
Alpine packages `resize2fs` in `e2fsprogs-extra`, going back at least as far as Alpine 3.16:

ref: https://pkgs.alpinelinux.org/contents?file=resize2fs&path=&name=&branch=v3.16

Some other parts of the repo already document this:

- `host/src/alpine/utils.rs`
- `docs/custom-images.md`

I left a single comment un-changed, as (best I could tell), it was in a distro-agnostic context:
- `host/src/vm/core.ts:1614`

I left `host/src/build/container.ts` unchanged, as to the best of my understanding, the container there does not implicitly hit any resize paths. Happy to update this if I'm wrong, to maintain consistency, etc.

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

**Note from @torrancew: This repo does not contain a `CONTRIBUTING.md`. I have read, understood, and applied the relevant sections from the `earendil-works/pi` `CONTRIBUTING.md` in its absence.**

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
