### PR TITLE
fix(http bridge): let undici own Content-Length for buffered request bodies

### DIFF
--- a/host/src/qemu/http.ts
+++ b/host/src/qemu/http.ts
@@ -731,18 +731,18 @@ export async function handleHttpDataWithWriter(
         url: baseRequest.url,
         headers: {
           ...baseRequest.headers,
-          "content-length": body.length.toString(),
         },
         body: body.length > 0 ? body : null,
       };
 
-      request.headers = { ...request.headers };
-      delete request.headers["transfer-encoding"];
-      if (request.body) {
-        request.headers["content-length"] = request.body.length.toString();
-      } else {
-        delete request.headers["content-length"];
-      }
+	request.headers = { ...request.headers };
+	delete request.headers["transfer-encoding"];
+	// Let undici compute Content-Length from the buffered body. Node >= 24.17's
+	// undici rejects a manually supplied Content-Length for a buffered body
+	// ("invalid content-length header"), which surfaced as a 502 for buffered
+	// request bodies (issue #134). undici sets an accurate Content-Length
+	// automatically for buffered/string bodies.
+	delete request.headers["content-length"];
 
       httpSession.processing = true;
       let releaseHttpConcurrency: (() => void) | null = null;
@@ -1015,11 +1015,12 @@ export async function handleHttpDataWithWriter(
     // Normalize framing headers for fetch.
     request.headers = { ...request.headers };
     delete request.headers["transfer-encoding"];
-    if (request.body) {
-      request.headers["content-length"] = request.body.length.toString();
-    } else {
-      delete request.headers["content-length"];
-    }
+    // Let undici compute Content-Length from the buffered body. Node >= 24.17's
+    // undici rejects a manually supplied Content-Length for a buffered body
+    // ("invalid content-length header"), which surfaced as a 502 for buffered
+    // request bodies (issue #134). undici sets an accurate Content-Length
+    // automatically for buffered/string bodies.
+    delete request.headers["content-length"];
 
     httpSession.processing = true;
     let releaseHttpConcurrency: (() => void) | null = null;


### PR DESCRIPTION
Resolves #134.

On Node.js >= 24.17, undici rejects a manually supplied `Content-Length` header for a buffered request body (`invalid content-length header`). The bridge forwards buffered request bodies with a manually set `Content-Length`, so undici throws and the bridge returns a 502 for buffered request bodies.

Changes in `host/src/qemu/http.ts`:
- On the buffered request paths (content-length-complete and chunked-complete), stop setting `Content-Length` manually; undici computes an accurate `Content-Length` from the buffered body automatically.
- The incoming `Content-Length` is still normalized during request parsing.

Note: I could not run the full gondolin test suite here (needs pnpm + QEMU). The change is minimal and scoped to the two buffered-body completion paths; please verify on CI across the supported Node versions (esp. >= 24.17).